### PR TITLE
Add static PNSQC site pages and shared stylesheet

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -80,7 +80,6 @@ out
 
 # Nuxt.js build / generate output
 .nuxt
-dist
 
 # Gatsby files
 .cache/

--- a/dist/about.html
+++ b/dist/about.html
@@ -1,0 +1,131 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>About PNSQC</title>
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <header>
+      <div class="container navbar">
+        <a class="brand" href="index.html">
+          <span class="brand-badge">PNS</span>
+          <div>
+            <strong>PNSQC</strong>
+            <div style="font-size: 0.75rem; opacity: 0.8;">Pacific Northwest Software Quality Conference</div>
+          </div>
+        </a>
+        <nav aria-label="Primary">
+          <ul>
+            <li><a href="about.html">About</a></li>
+            <li><a href="conference.html">Conference</a></li>
+            <li><a href="program.html">Program</a></li>
+            <li><a href="attend.html">Attend</a></li>
+            <li><a href="sponsors.html">Sponsors</a></li>
+            <li><a href="contact.html">Contact</a></li>
+          </ul>
+        </nav>
+      </div>
+    </header>
+
+    <section class="page-hero">
+      <div class="container">
+        <div class="breadcrumb">Home / About</div>
+        <h1>About PNSQC</h1>
+        <p>For over four decades, PNSQC has brought together the Pacific Northwest quality community.</p>
+      </div>
+    </section>
+
+    <main class="container">
+      <section class="section">
+        <h2>Our mission</h2>
+        <p class="lead">
+          PNSQC is a volunteer-led, nonprofit conference committed to advancing software quality practices through
+          education, collaboration, and professional growth.
+        </p>
+        <div class="card-grid">
+          <article class="card">
+            <h3>Community-driven</h3>
+            <p>Our steering committee and program teams are made up of practitioners who shape the conference each year.</p>
+          </article>
+          <article class="card">
+            <h3>Practical learning</h3>
+            <p>We curate talks, workshops, and forums that highlight real-world experiences and applied techniques.</p>
+          </article>
+          <article class="card">
+            <h3>Inclusive growth</h3>
+            <p>We welcome professionals across roles and career stages, fostering mentorship and diverse perspectives.</p>
+          </article>
+        </div>
+      </section>
+
+      <section class="section split">
+        <div>
+          <h2>Conference leadership</h2>
+          <p class="lead">
+            PNSQC is guided by a board of directors and program leaders responsible for the conference vision, finances,
+            and community partnerships.
+          </p>
+          <ul class="info-list">
+            <li><strong>Board of Directors</strong> oversees strategy, governance, and long-term sustainability.</li>
+            <li><strong>Program Committee</strong> curates sessions, workshops, and speakers.</li>
+            <li><strong>Volunteer teams</strong> support marketing, operations, sponsorship, and attendee experience.</li>
+          </ul>
+        </div>
+        <div class="callout">
+          <h3>Get involved</h3>
+          <p>
+            Interested in volunteering, speaking, or mentoring? We welcome new voices and fresh ideas every year.
+          </p>
+          <div class="hero-actions" style="margin-top: 1.2rem;">
+            <a class="button primary" href="contact.html">Connect with the team</a>
+          </div>
+        </div>
+      </section>
+
+      <section class="section">
+        <h2>Values we uphold</h2>
+        <div class="card-grid">
+          <article class="card">
+            <h3>Integrity</h3>
+            <p>We prioritize honest dialogue, constructive feedback, and data-backed decision-making.</p>
+          </article>
+          <article class="card">
+            <h3>Curiosity</h3>
+            <p>We celebrate experimentation, continuous learning, and the craft of software quality.</p>
+          </article>
+          <article class="card">
+            <h3>Belonging</h3>
+            <p>We create spaces where every attendee feels respected, welcomed, and empowered.</p>
+          </article>
+        </div>
+      </section>
+    </main>
+
+    <footer>
+      <div class="container footer-grid">
+        <div>
+          <strong>PNSQC</strong>
+          <p>Pacific Northwest Software Quality Conference</p>
+          <p>Connecting the software quality community since 1983.</p>
+        </div>
+        <div>
+          <strong>Explore</strong>
+          <ul>
+            <li><a href="program.html">Program</a></li>
+            <li><a href="conference.html">Conference week</a></li>
+            <li><a href="sponsors.html">Sponsorship</a></li>
+          </ul>
+        </div>
+        <div>
+          <strong>Contact</strong>
+          <ul>
+            <li><a href="contact.html">Contact the team</a></li>
+            <li><a href="attend.html">Registration</a></li>
+          </ul>
+        </div>
+      </div>
+    </footer>
+  </body>
+</html>

--- a/dist/attend.html
+++ b/dist/attend.html
@@ -1,0 +1,132 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Attend | PNSQC</title>
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <header>
+      <div class="container navbar">
+        <a class="brand" href="index.html">
+          <span class="brand-badge">PNS</span>
+          <div>
+            <strong>PNSQC</strong>
+            <div style="font-size: 0.75rem; opacity: 0.8;">Pacific Northwest Software Quality Conference</div>
+          </div>
+        </a>
+        <nav aria-label="Primary">
+          <ul>
+            <li><a href="about.html">About</a></li>
+            <li><a href="conference.html">Conference</a></li>
+            <li><a href="program.html">Program</a></li>
+            <li><a href="attend.html">Attend</a></li>
+            <li><a href="sponsors.html">Sponsors</a></li>
+            <li><a href="contact.html">Contact</a></li>
+          </ul>
+        </nav>
+      </div>
+    </header>
+
+    <section class="page-hero">
+      <div class="container">
+        <div class="breadcrumb">Home / Attend</div>
+        <h1>Attend PNSQC</h1>
+        <p>Registration options designed for teams, leaders, and individual contributors.</p>
+      </div>
+    </section>
+
+    <main class="container">
+      <section class="section">
+        <h2>Registration options</h2>
+        <p class="lead">
+          Choose a pass that matches your schedule and goals. Discounts are available for early registration, students,
+          and group packages.
+        </p>
+        <div class="card-grid">
+          <article class="card">
+            <span class="tag">Full week</span>
+            <h3>All-access pass</h3>
+            <p>Includes workshops, tutorials, conference sessions, recordings, and community events.</p>
+          </article>
+          <article class="card">
+            <span class="tag">Conference days</span>
+            <h3>Main conference</h3>
+            <p>Access to keynotes, breakout sessions, sponsor showcases, and networking events.</p>
+          </article>
+          <article class="card">
+            <span class="tag">Workshops</span>
+            <h3>Training add-ons</h3>
+            <p>Deep-dive learning with expert instructors for specialized topics and tools.</p>
+          </article>
+        </div>
+      </section>
+
+      <section class="section split">
+        <div>
+          <h2>Travel &amp; lodging</h2>
+          <p class="lead">
+            PNSQC partners with hotels near the venue for discounted rates. The location is easily accessible by public
+            transit and offers nearby dining and attractions.
+          </p>
+          <ul class="info-list">
+            <li><strong>Hotel block</strong> available for conference attendees.</li>
+            <li><strong>Transit access</strong> via light rail, rideshare, and regional buses.</li>
+            <li><strong>Virtual option</strong> for remote attendees with live-stream access.</li>
+          </ul>
+        </div>
+        <div class="callout">
+          <h3>Need a justification letter?</h3>
+          <p>We provide templates to help attendees request training budgets and manager approval.</p>
+          <div class="hero-actions" style="margin-top: 1.2rem;">
+            <a class="button primary" href="contact.html">Request a template</a>
+          </div>
+        </div>
+      </section>
+
+      <section class="section">
+        <h2>Attendee resources</h2>
+        <div class="card-grid">
+          <article class="card">
+            <h3>Code of conduct</h3>
+            <p>We are committed to a safe, inclusive, and respectful conference experience for all attendees.</p>
+          </article>
+          <article class="card">
+            <h3>Accessibility</h3>
+            <p>Captioning, accessible facilities, and dietary accommodations are available upon request.</p>
+          </article>
+          <article class="card">
+            <h3>Community events</h3>
+            <p>Daily networking meetups, mentoring circles, and sponsor receptions.</p>
+          </article>
+        </div>
+      </section>
+    </main>
+
+    <footer>
+      <div class="container footer-grid">
+        <div>
+          <strong>PNSQC</strong>
+          <p>Pacific Northwest Software Quality Conference</p>
+          <p>Connecting the software quality community since 1983.</p>
+        </div>
+        <div>
+          <strong>Explore</strong>
+          <ul>
+            <li><a href="program.html">Program</a></li>
+            <li><a href="conference.html">Conference week</a></li>
+            <li><a href="sponsors.html">Sponsorship</a></li>
+          </ul>
+        </div>
+        <div>
+          <strong>Contact</strong>
+          <ul>
+            <li><a href="contact.html">Contact the team</a></li>
+            <li><a href="attend.html">Registration</a></li>
+          </ul>
+        </div>
+      </div>
+    </footer>
+  </body>
+</html>

--- a/dist/conference.html
+++ b/dist/conference.html
@@ -1,0 +1,134 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Conference Week | PNSQC</title>
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <header>
+      <div class="container navbar">
+        <a class="brand" href="index.html">
+          <span class="brand-badge">PNS</span>
+          <div>
+            <strong>PNSQC</strong>
+            <div style="font-size: 0.75rem; opacity: 0.8;">Pacific Northwest Software Quality Conference</div>
+          </div>
+        </a>
+        <nav aria-label="Primary">
+          <ul>
+            <li><a href="about.html">About</a></li>
+            <li><a href="conference.html">Conference</a></li>
+            <li><a href="program.html">Program</a></li>
+            <li><a href="attend.html">Attend</a></li>
+            <li><a href="sponsors.html">Sponsors</a></li>
+            <li><a href="contact.html">Contact</a></li>
+          </ul>
+        </nav>
+      </div>
+    </header>
+
+    <section class="page-hero">
+      <div class="container">
+        <div class="breadcrumb">Home / Conference</div>
+        <h1>Conference week overview</h1>
+        <p>Design your experience with a mix of workshops, keynotes, and networking sessions.</p>
+      </div>
+    </section>
+
+    <main class="container">
+      <section class="section">
+        <h2>Signature experiences</h2>
+        <p class="lead">
+          Every day of PNSQC is built around immersive learning, practical takeaways, and opportunities to connect with
+          peers across the quality community.
+        </p>
+        <div class="card-grid">
+          <article class="card">
+            <h3>Hands-on workshops</h3>
+            <p>Facilitated sessions that provide guided practice with tools, frameworks, and techniques.</p>
+          </article>
+          <article class="card">
+            <h3>Keynotes &amp; panels</h3>
+            <p>Industry leaders share strategic insights on quality engineering, testing, and product delivery.</p>
+          </article>
+          <article class="card">
+            <h3>Community forums</h3>
+            <p>Interactive discussions centered on leadership, career growth, and emerging challenges.</p>
+          </article>
+        </div>
+      </section>
+
+      <section class="section">
+        <h2>Weekly flow</h2>
+        <div class="timeline">
+          <div class="timeline-item">
+            <strong>Monday</strong> · Multi-hour workshops and deep-dive courses
+          </div>
+          <div class="timeline-item">
+            <strong>Tuesday</strong> · Tutorials, leadership labs, and small group forums
+          </div>
+          <div class="timeline-item">
+            <strong>Wednesday</strong> · Opening keynote, sponsor showcase, breakout sessions
+          </div>
+          <div class="timeline-item">
+            <strong>Thursday</strong> · Conference sessions, panels, and community reception
+          </div>
+          <div class="timeline-item">
+            <strong>Friday</strong> · Certification prep, practitioner roundtables, and closing keynote
+          </div>
+        </div>
+      </section>
+
+      <section class="section split">
+        <div>
+          <h2>Venue &amp; participation</h2>
+          <p class="lead">
+            Join in person in the Seattle metro area or attend virtually with live-streamed sessions and on-demand
+            access. Attendees receive digital proceedings and session recordings.
+          </p>
+          <ul class="info-list">
+            <li><strong>Hybrid access</strong> for conference sessions and selected workshops.</li>
+            <li><strong>Networking lounges</strong> with sponsor meet-and-greets and community activities.</li>
+            <li><strong>Accessibility-first</strong> with captioning, accessible rooms, and dietary options.</li>
+          </ul>
+        </div>
+        <div class="callout">
+          <h3>Conference add-ons</h3>
+          <p>
+            Customize your experience with leadership forums, certification prep sessions, and hands-on training.
+          </p>
+          <div class="hero-actions" style="margin-top: 1.2rem;">
+            <a class="button primary" href="attend.html">Explore passes</a>
+          </div>
+        </div>
+      </section>
+    </main>
+
+    <footer>
+      <div class="container footer-grid">
+        <div>
+          <strong>PNSQC</strong>
+          <p>Pacific Northwest Software Quality Conference</p>
+          <p>Connecting the software quality community since 1983.</p>
+        </div>
+        <div>
+          <strong>Explore</strong>
+          <ul>
+            <li><a href="program.html">Program</a></li>
+            <li><a href="conference.html">Conference week</a></li>
+            <li><a href="sponsors.html">Sponsorship</a></li>
+          </ul>
+        </div>
+        <div>
+          <strong>Contact</strong>
+          <ul>
+            <li><a href="contact.html">Contact the team</a></li>
+            <li><a href="attend.html">Registration</a></li>
+          </ul>
+        </div>
+      </div>
+    </footer>
+  </body>
+</html>

--- a/dist/contact.html
+++ b/dist/contact.html
@@ -1,0 +1,113 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Contact | PNSQC</title>
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <header>
+      <div class="container navbar">
+        <a class="brand" href="index.html">
+          <span class="brand-badge">PNS</span>
+          <div>
+            <strong>PNSQC</strong>
+            <div style="font-size: 0.75rem; opacity: 0.8;">Pacific Northwest Software Quality Conference</div>
+          </div>
+        </a>
+        <nav aria-label="Primary">
+          <ul>
+            <li><a href="about.html">About</a></li>
+            <li><a href="conference.html">Conference</a></li>
+            <li><a href="program.html">Program</a></li>
+            <li><a href="attend.html">Attend</a></li>
+            <li><a href="sponsors.html">Sponsors</a></li>
+            <li><a href="contact.html">Contact</a></li>
+          </ul>
+        </nav>
+      </div>
+    </header>
+
+    <section class="page-hero">
+      <div class="container">
+        <div class="breadcrumb">Home / Contact</div>
+        <h1>Contact the PNSQC team</h1>
+        <p>We are here to help with registration, proposals, sponsorship, and volunteer opportunities.</p>
+      </div>
+    </section>
+
+    <main class="container">
+      <section class="section split">
+        <div>
+          <h2>General inquiries</h2>
+          <p class="lead">
+            Reach out with questions about conference logistics, registration changes, accessibility, or community
+            partnerships.
+          </p>
+          <ul class="info-list">
+            <li><strong>Email</strong> · info@pnsqc.org</li>
+            <li><strong>Volunteer team</strong> · volunteer@pnsqc.org</li>
+            <li><strong>Sponsorships</strong> · sponsors@pnsqc.org</li>
+          </ul>
+        </div>
+        <div class="callout">
+          <h3>Stay connected</h3>
+          <p>Subscribe to announcements about registration, schedules, and speaker updates.</p>
+          <div class="hero-actions" style="margin-top: 1.2rem;">
+            <a class="button primary" href="attend.html">Join the mailing list</a>
+          </div>
+        </div>
+      </section>
+
+      <section class="section">
+        <h2>Frequently asked questions</h2>
+        <div class="card-grid">
+          <article class="card">
+            <h3>How do I register a team?</h3>
+            <p>Group registration packages are available with discounted pricing for teams of five or more.</p>
+          </article>
+          <article class="card">
+            <h3>Are sessions recorded?</h3>
+            <p>Yes. Registered attendees receive on-demand access to session recordings after the event.</p>
+          </article>
+          <article class="card">
+            <h3>Can I volunteer?</h3>
+            <p>Volunteers receive complimentary access and help with onsite logistics and community support.</p>
+          </article>
+        </div>
+      </section>
+
+      <section class="section">
+        <div class="notice">
+          Looking for a specific committee or speaker contact? Let us know and we will connect you with the right team.
+        </div>
+      </section>
+    </main>
+
+    <footer>
+      <div class="container footer-grid">
+        <div>
+          <strong>PNSQC</strong>
+          <p>Pacific Northwest Software Quality Conference</p>
+          <p>Connecting the software quality community since 1983.</p>
+        </div>
+        <div>
+          <strong>Explore</strong>
+          <ul>
+            <li><a href="program.html">Program</a></li>
+            <li><a href="conference.html">Conference week</a></li>
+            <li><a href="sponsors.html">Sponsorship</a></li>
+          </ul>
+        </div>
+        <div>
+          <strong>Contact</strong>
+          <ul>
+            <li><a href="contact.html">Contact the team</a></li>
+            <li><a href="attend.html">Registration</a></li>
+          </ul>
+        </div>
+      </div>
+    </footer>
+  </body>
+</html>

--- a/dist/index.html
+++ b/dist/index.html
@@ -1,0 +1,172 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>PNSQC | Pacific Northwest Software Quality Conference</title>
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <header>
+      <div class="container navbar">
+        <a class="brand" href="index.html">
+          <span class="brand-badge">PNS</span>
+          <div>
+            <strong>PNSQC</strong>
+            <div style="font-size: 0.75rem; opacity: 0.8;">Pacific Northwest Software Quality Conference</div>
+          </div>
+        </a>
+        <nav aria-label="Primary">
+          <ul>
+            <li><a href="about.html">About</a></li>
+            <li><a href="conference.html">Conference</a></li>
+            <li><a href="program.html">Program</a></li>
+            <li><a href="attend.html">Attend</a></li>
+            <li><a href="sponsors.html">Sponsors</a></li>
+            <li><a href="contact.html">Contact</a></li>
+          </ul>
+        </nav>
+      </div>
+    </header>
+
+    <section class="hero">
+      <div class="container hero-grid">
+        <div>
+          <h1>Build quality into every release.</h1>
+          <p>
+            PNSQC connects software quality leaders, engineers, and product teams from across the Pacific Northwest for
+            a week of practical learning, collaboration, and community-building.
+          </p>
+          <div class="hero-actions">
+            <a class="button primary" href="attend.html">Register &amp; Attend</a>
+            <a class="button secondary" href="program.html">View Program</a>
+          </div>
+        </div>
+        <div class="hero-card">
+          <h3>Conference at a glance</h3>
+          <ul>
+            <li><strong>5 days</strong> of keynotes, workshops, and peer exchange</li>
+            <li><strong>40+ sessions</strong> curated across quality, AI, and delivery tracks</li>
+            <li><strong>Community events</strong> including mentoring circles and leadership forums</li>
+          </ul>
+        </div>
+      </div>
+    </section>
+
+    <main class="container">
+      <section class="section">
+        <h2>Why PNSQC</h2>
+        <p class="lead">
+          Since 1983, PNSQC has provided a practitioner-led forum for the people who care about building, shipping, and
+          sustaining trustworthy software. Our program blends strategic guidance with hands-on tools that attendees can
+          immediately apply.
+        </p>
+        <div class="card-grid">
+          <article class="card">
+            <span class="tag">Leadership</span>
+            <h3>Executive insights</h3>
+            <p>Hear how quality leaders scale reliability, governance, and customer trust across complex portfolios.</p>
+          </article>
+          <article class="card">
+            <span class="tag">Engineering</span>
+            <h3>Modern delivery</h3>
+            <p>Explore automation, observability, and AI-assisted testing strategies that keep teams shipping faster.</p>
+          </article>
+          <article class="card">
+            <span class="tag">Community</span>
+            <h3>Peer learning</h3>
+            <p>Join small-group exchanges, mentoring circles, and networking opportunities throughout the week.</p>
+          </article>
+        </div>
+      </section>
+
+      <section class="section">
+        <h2>Tracks &amp; focus areas</h2>
+        <div class="card-grid">
+          <article class="card">
+            <h3>Quality strategy</h3>
+            <p>Align quality objectives with business outcomes, metrics, and organizational change initiatives.</p>
+          </article>
+          <article class="card">
+            <h3>AI &amp; automation</h3>
+            <p>Apply machine learning, test automation, and data analytics to drive faster feedback cycles.</p>
+          </article>
+          <article class="card">
+            <h3>Engineering excellence</h3>
+            <p>Advance DevOps, performance engineering, and reliability practices for modern distributed systems.</p>
+          </article>
+          <article class="card">
+            <h3>People &amp; culture</h3>
+            <p>Build inclusive, high-performing quality teams with coaching, mentoring, and leadership development.</p>
+          </article>
+        </div>
+      </section>
+
+      <section class="section">
+        <h2>Plan your week</h2>
+        <p class="lead">A blend of immersive workshops and conference sessions keeps the momentum going all week long.</p>
+        <div class="timeline">
+          <div class="timeline-item">
+            <strong>Monday</strong> · Hands-on workshops and deep dives
+          </div>
+          <div class="timeline-item">
+            <strong>Tuesday</strong> · Tutorials, leadership labs, and community meetups
+          </div>
+          <div class="timeline-item">
+            <strong>Wednesday - Thursday</strong> · Conference keynotes, breakout sessions, and panels
+          </div>
+          <div class="timeline-item">
+            <strong>Friday</strong> · Certification prep, industry roundtables, and closing events
+          </div>
+        </div>
+      </section>
+
+      <section class="section split">
+        <div>
+          <h2>Where we gather</h2>
+          <p class="lead">
+            PNSQC takes place in the greater Seattle area with options for on-site and virtual participation. The
+            conference hotel sits minutes from downtown, transit, and the region's best dining.
+          </p>
+          <ul class="info-list">
+            <li><strong>Hybrid experience</strong> with live-streamed sessions and on-demand replays.</li>
+            <li><strong>Accessible venue</strong> with mobility-friendly spaces and quiet rooms.</li>
+            <li><strong>Community lounges</strong> designed for networking and sponsor showcases.</li>
+          </ul>
+        </div>
+        <div class="callout">
+          <h3>Ready to join us?</h3>
+          <p>Registration opens soon. Save your spot for workshops, leadership forums, and the conference program.</p>
+          <div class="hero-actions" style="margin-top: 1.2rem;">
+            <a class="button primary" href="attend.html">See registration options</a>
+          </div>
+        </div>
+      </section>
+    </main>
+
+    <footer>
+      <div class="container footer-grid">
+        <div>
+          <strong>PNSQC</strong>
+          <p>Pacific Northwest Software Quality Conference</p>
+          <p>Connecting the software quality community since 1983.</p>
+        </div>
+        <div>
+          <strong>Explore</strong>
+          <ul>
+            <li><a href="program.html">Program</a></li>
+            <li><a href="conference.html">Conference week</a></li>
+            <li><a href="sponsors.html">Sponsorship</a></li>
+          </ul>
+        </div>
+        <div>
+          <strong>Contact</strong>
+          <ul>
+            <li><a href="contact.html">Contact the team</a></li>
+            <li><a href="attend.html">Registration</a></li>
+          </ul>
+        </div>
+      </div>
+    </footer>
+  </body>
+</html>

--- a/dist/program.html
+++ b/dist/program.html
@@ -1,0 +1,160 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Program | PNSQC</title>
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <header>
+      <div class="container navbar">
+        <a class="brand" href="index.html">
+          <span class="brand-badge">PNS</span>
+          <div>
+            <strong>PNSQC</strong>
+            <div style="font-size: 0.75rem; opacity: 0.8;">Pacific Northwest Software Quality Conference</div>
+          </div>
+        </a>
+        <nav aria-label="Primary">
+          <ul>
+            <li><a href="about.html">About</a></li>
+            <li><a href="conference.html">Conference</a></li>
+            <li><a href="program.html">Program</a></li>
+            <li><a href="attend.html">Attend</a></li>
+            <li><a href="sponsors.html">Sponsors</a></li>
+            <li><a href="contact.html">Contact</a></li>
+          </ul>
+        </nav>
+      </div>
+    </header>
+
+    <section class="page-hero">
+      <div class="container">
+        <div class="breadcrumb">Home / Program</div>
+        <h1>Program highlights</h1>
+        <p>Preview the sessions, topics, and formats planned for the conference week.</p>
+      </div>
+    </section>
+
+    <main class="container">
+      <section class="section">
+        <h2>Featured session formats</h2>
+        <p class="lead">
+          PNSQC offers a mix of keynotes, breakout sessions, tutorials, and interactive labs to meet diverse learning
+          needs.
+        </p>
+        <div class="card-grid">
+          <article class="card">
+            <span class="tag">Keynote</span>
+            <h3>Visionary talks</h3>
+            <p>Industry leaders share the future of quality engineering, AI, and software delivery.</p>
+          </article>
+          <article class="card">
+            <span class="tag">Breakout</span>
+            <h3>Practical sessions</h3>
+            <p>Case studies and lessons learned from teams navigating real-world quality challenges.</p>
+          </article>
+          <article class="card">
+            <span class="tag">Tutorial</span>
+            <h3>Guided learning</h3>
+            <p>Structured, instructor-led walkthroughs for new tools, frameworks, and methodologies.</p>
+          </article>
+          <article class="card">
+            <span class="tag">Forum</span>
+            <h3>Community exchange</h3>
+            <p>Facilitated discussions for leaders, managers, and practitioners to share insights.</p>
+          </article>
+        </div>
+      </section>
+
+      <section class="section">
+        <h2>Sample agenda</h2>
+        <p class="lead">A snapshot of conference sessions to help you plan your schedule.</p>
+        <table class="table" aria-label="Sample agenda">
+          <thead>
+            <tr>
+              <th>Time</th>
+              <th>Session</th>
+              <th>Track</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>9:00 AM</td>
+              <td>Opening keynote: Quality leadership in an AI-first world</td>
+              <td>Leadership</td>
+            </tr>
+            <tr>
+              <td>10:30 AM</td>
+              <td>Building resilient test automation pipelines</td>
+              <td>Engineering Excellence</td>
+            </tr>
+            <tr>
+              <td>1:00 PM</td>
+              <td>Continuous quality metrics that executives trust</td>
+              <td>Quality Strategy</td>
+            </tr>
+            <tr>
+              <td>2:30 PM</td>
+              <td>Exploratory testing in modern product teams</td>
+              <td>People &amp; Culture</td>
+            </tr>
+            <tr>
+              <td>4:00 PM</td>
+              <td>Panel: Scaling quality with distributed teams</td>
+              <td>Community Forum</td>
+            </tr>
+          </tbody>
+        </table>
+      </section>
+
+      <section class="section split">
+        <div>
+          <h2>Call for proposals</h2>
+          <p class="lead">
+            We invite speakers to share stories, frameworks, and research that help the community elevate software
+            quality. Submissions are reviewed by the program committee and selected based on impact and relevance.
+          </p>
+          <ul class="info-list">
+            <li><strong>Session lengths</strong> range from 30 to 90 minutes, including Q&amp;A.</li>
+            <li><strong>Formats</strong> include workshops, panels, and lightning talks.</li>
+            <li><strong>Support</strong> available for first-time speakers and new topics.</li>
+          </ul>
+        </div>
+        <div class="callout">
+          <h3>Program updates</h3>
+          <p>Full schedules and speaker profiles will be published as sessions are confirmed.</p>
+          <div class="hero-actions" style="margin-top: 1.2rem;">
+            <a class="button primary" href="contact.html">Submit a proposal</a>
+          </div>
+        </div>
+      </section>
+    </main>
+
+    <footer>
+      <div class="container footer-grid">
+        <div>
+          <strong>PNSQC</strong>
+          <p>Pacific Northwest Software Quality Conference</p>
+          <p>Connecting the software quality community since 1983.</p>
+        </div>
+        <div>
+          <strong>Explore</strong>
+          <ul>
+            <li><a href="program.html">Program</a></li>
+            <li><a href="conference.html">Conference week</a></li>
+            <li><a href="sponsors.html">Sponsorship</a></li>
+          </ul>
+        </div>
+        <div>
+          <strong>Contact</strong>
+          <ul>
+            <li><a href="contact.html">Contact the team</a></li>
+            <li><a href="attend.html">Registration</a></li>
+          </ul>
+        </div>
+      </div>
+    </footer>
+  </body>
+</html>

--- a/dist/sponsors.html
+++ b/dist/sponsors.html
@@ -1,0 +1,142 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Sponsors | PNSQC</title>
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <header>
+      <div class="container navbar">
+        <a class="brand" href="index.html">
+          <span class="brand-badge">PNS</span>
+          <div>
+            <strong>PNSQC</strong>
+            <div style="font-size: 0.75rem; opacity: 0.8;">Pacific Northwest Software Quality Conference</div>
+          </div>
+        </a>
+        <nav aria-label="Primary">
+          <ul>
+            <li><a href="about.html">About</a></li>
+            <li><a href="conference.html">Conference</a></li>
+            <li><a href="program.html">Program</a></li>
+            <li><a href="attend.html">Attend</a></li>
+            <li><a href="sponsors.html">Sponsors</a></li>
+            <li><a href="contact.html">Contact</a></li>
+          </ul>
+        </nav>
+      </div>
+    </header>
+
+    <section class="page-hero">
+      <div class="container">
+        <div class="breadcrumb">Home / Sponsors</div>
+        <h1>Sponsorship opportunities</h1>
+        <p>Partner with PNSQC to connect with quality leaders and practitioners.</p>
+      </div>
+    </section>
+
+    <main class="container">
+      <section class="section">
+        <h2>Why sponsor</h2>
+        <p class="lead">
+          Sponsors help make PNSQC accessible while gaining visibility with teams who influence tooling, training, and
+          quality investments across the region.
+        </p>
+        <div class="card-grid">
+          <article class="card">
+            <h3>Connect with buyers</h3>
+            <p>Meet decision-makers and practitioners who evaluate testing platforms, training, and services.</p>
+          </article>
+          <article class="card">
+            <h3>Showcase expertise</h3>
+            <p>Lead demos, case studies, or roundtables to share your perspective on quality engineering.</p>
+          </article>
+          <article class="card">
+            <h3>Support the community</h3>
+            <p>Help fund scholarships, mentorship, and programs that expand access to learning.</p>
+          </article>
+        </div>
+      </section>
+
+      <section class="section">
+        <h2>Sponsorship levels</h2>
+        <table class="table" aria-label="Sponsorship levels">
+          <thead>
+            <tr>
+              <th>Level</th>
+              <th>Visibility</th>
+              <th>Highlights</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>Platinum</td>
+              <td>Highest</td>
+              <td>Keynote recognition, premium booth, featured session slot</td>
+            </tr>
+            <tr>
+              <td>Gold</td>
+              <td>High</td>
+              <td>Prominent signage, breakout session sponsorship, digital promotion</td>
+            </tr>
+            <tr>
+              <td>Silver</td>
+              <td>Medium</td>
+              <td>Exhibit space, attendee list access, branded lounge</td>
+            </tr>
+            <tr>
+              <td>Community</td>
+              <td>Targeted</td>
+              <td>Scholarship support, community reception, volunteer recognition</td>
+            </tr>
+          </tbody>
+        </table>
+      </section>
+
+      <section class="section split">
+        <div>
+          <h2>What sponsors receive</h2>
+          <ul class="info-list">
+            <li><strong>Multi-channel promotion</strong> across email, social, and onsite signage.</li>
+            <li><strong>Onsite presence</strong> with exhibit areas and networking opportunities.</li>
+            <li><strong>Thought leadership</strong> through sponsor talks, demos, or panel participation.</li>
+          </ul>
+        </div>
+        <div class="callout">
+          <h3>Get the sponsor prospectus</h3>
+          <p>We offer customizable packages for startups, enterprise partners, and community organizations.</p>
+          <div class="hero-actions" style="margin-top: 1.2rem;">
+            <a class="button primary" href="contact.html">Request sponsorship info</a>
+          </div>
+        </div>
+      </section>
+    </main>
+
+    <footer>
+      <div class="container footer-grid">
+        <div>
+          <strong>PNSQC</strong>
+          <p>Pacific Northwest Software Quality Conference</p>
+          <p>Connecting the software quality community since 1983.</p>
+        </div>
+        <div>
+          <strong>Explore</strong>
+          <ul>
+            <li><a href="program.html">Program</a></li>
+            <li><a href="conference.html">Conference week</a></li>
+            <li><a href="sponsors.html">Sponsorship</a></li>
+          </ul>
+        </div>
+        <div>
+          <strong>Contact</strong>
+          <ul>
+            <li><a href="contact.html">Contact the team</a></li>
+            <li><a href="attend.html">Registration</a></li>
+          </ul>
+        </div>
+      </div>
+    </footer>
+  </body>
+</html>

--- a/dist/styles.css
+++ b/dist/styles.css
@@ -1,0 +1,355 @@
+:root {
+  color-scheme: light;
+  --blue-900: #0b1b3b;
+  --blue-700: #133a7c;
+  --blue-500: #2c6bed;
+  --blue-100: #e8f1ff;
+  --slate-900: #0f172a;
+  --slate-700: #334155;
+  --slate-500: #64748b;
+  --slate-200: #e2e8f0;
+  --white: #ffffff;
+  --accent: #f9a826;
+  --shadow: 0 20px 40px rgba(15, 23, 42, 0.12);
+  font-size: 16px;
+}
+
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  font-family: "Inter", "Segoe UI", system-ui, sans-serif;
+  color: var(--slate-900);
+  background: #f8fafc;
+  line-height: 1.6;
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}
+
+img {
+  max-width: 100%;
+  display: block;
+}
+
+.container {
+  width: min(1120px, 90%);
+  margin: 0 auto;
+}
+
+header {
+  background: var(--blue-900);
+  color: var(--white);
+  position: sticky;
+  top: 0;
+  z-index: 10;
+  box-shadow: 0 4px 18px rgba(15, 23, 42, 0.35);
+}
+
+.navbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 1.2rem 0;
+  gap: 2rem;
+}
+
+.brand {
+  display: flex;
+  align-items: center;
+  gap: 0.8rem;
+  font-weight: 700;
+  font-size: 1.1rem;
+}
+
+.brand-badge {
+  width: 44px;
+  height: 44px;
+  border-radius: 12px;
+  background: linear-gradient(135deg, var(--accent), #ffcf66);
+  color: var(--blue-900);
+  display: grid;
+  place-items: center;
+  font-weight: 800;
+}
+
+nav ul {
+  display: flex;
+  gap: 1.2rem;
+  list-style: none;
+  flex-wrap: wrap;
+  font-size: 0.95rem;
+}
+
+nav a {
+  padding: 0.4rem 0.6rem;
+  border-radius: 999px;
+  transition: background 0.2s ease;
+}
+
+nav a:hover,
+nav a:focus {
+  background: rgba(255, 255, 255, 0.15);
+}
+
+.hero {
+  background: radial-gradient(circle at top left, rgba(44, 107, 237, 0.3), transparent 55%),
+    radial-gradient(circle at top right, rgba(249, 168, 38, 0.3), transparent 50%),
+    var(--blue-900);
+  color: var(--white);
+  padding: 5.5rem 0 4rem;
+}
+
+.hero-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 3rem;
+  align-items: center;
+}
+
+.hero h1 {
+  font-size: clamp(2.4rem, 4vw, 3.6rem);
+  line-height: 1.1;
+  margin-bottom: 1.2rem;
+}
+
+.hero p {
+  font-size: 1.05rem;
+  color: rgba(255, 255, 255, 0.85);
+  margin-bottom: 2rem;
+}
+
+.hero-actions {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+.button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  padding: 0.75rem 1.6rem;
+  border-radius: 999px;
+  font-weight: 600;
+  border: 1px solid transparent;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.button.primary {
+  background: var(--accent);
+  color: var(--blue-900);
+  box-shadow: var(--shadow);
+}
+
+.button.secondary {
+  background: transparent;
+  border-color: rgba(255, 255, 255, 0.4);
+  color: var(--white);
+}
+
+.button:hover {
+  transform: translateY(-2px);
+}
+
+.hero-card {
+  background: rgba(255, 255, 255, 0.1);
+  padding: 2rem;
+  border-radius: 24px;
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  backdrop-filter: blur(8px);
+}
+
+.hero-card h3 {
+  margin-bottom: 0.6rem;
+  font-size: 1.2rem;
+}
+
+.hero-card ul {
+  list-style: none;
+  display: grid;
+  gap: 0.6rem;
+  color: rgba(255, 255, 255, 0.85);
+}
+
+main {
+  padding: 4.5rem 0;
+}
+
+.section {
+  margin-bottom: 4rem;
+}
+
+.section h2 {
+  font-size: clamp(1.6rem, 3vw, 2.2rem);
+  margin-bottom: 1rem;
+}
+
+.section p.lead {
+  color: var(--slate-700);
+  max-width: 720px;
+  margin-bottom: 2rem;
+}
+
+.card-grid {
+  display: grid;
+  gap: 1.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.card {
+  background: var(--white);
+  padding: 1.8rem;
+  border-radius: 20px;
+  border: 1px solid var(--slate-200);
+  box-shadow: 0 10px 24px rgba(15, 23, 42, 0.06);
+}
+
+.card h3 {
+  margin-bottom: 0.6rem;
+}
+
+.tag {
+  display: inline-block;
+  padding: 0.2rem 0.7rem;
+  border-radius: 999px;
+  background: var(--blue-100);
+  color: var(--blue-700);
+  font-size: 0.75rem;
+  font-weight: 600;
+  margin-bottom: 0.8rem;
+}
+
+.timeline {
+  display: grid;
+  gap: 1rem;
+}
+
+.timeline-item {
+  background: var(--white);
+  border-radius: 18px;
+  padding: 1.2rem 1.5rem;
+  border-left: 4px solid var(--blue-500);
+  box-shadow: 0 10px 20px rgba(15, 23, 42, 0.05);
+}
+
+.split {
+  display: grid;
+  gap: 2rem;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  align-items: start;
+}
+
+.info-list {
+  list-style: none;
+  display: grid;
+  gap: 0.7rem;
+  color: var(--slate-700);
+}
+
+.info-list strong {
+  color: var(--slate-900);
+}
+
+.callout {
+  background: linear-gradient(135deg, #fff8ec, #ffffff);
+  border: 1px solid #fde6bd;
+  border-radius: 18px;
+  padding: 1.6rem;
+}
+
+footer {
+  background: var(--slate-900);
+  color: var(--white);
+  padding: 2.5rem 0;
+}
+
+.footer-grid {
+  display: grid;
+  gap: 1.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+footer p,
+footer li {
+  color: rgba(255, 255, 255, 0.8);
+  font-size: 0.95rem;
+}
+
+footer ul {
+  list-style: none;
+  display: grid;
+  gap: 0.4rem;
+}
+
+footer a {
+  color: inherit;
+}
+
+.page-hero {
+  background: var(--blue-900);
+  color: var(--white);
+  padding: 3rem 0;
+}
+
+.page-hero h1 {
+  font-size: clamp(2rem, 3vw, 2.6rem);
+  margin-bottom: 0.6rem;
+}
+
+.breadcrumb {
+  color: rgba(255, 255, 255, 0.7);
+  font-size: 0.9rem;
+}
+
+.table {
+  width: 100%;
+  border-collapse: collapse;
+  background: var(--white);
+  border-radius: 16px;
+  overflow: hidden;
+  box-shadow: 0 8px 18px rgba(15, 23, 42, 0.05);
+}
+
+.table th,
+.table td {
+  padding: 1rem;
+  text-align: left;
+  border-bottom: 1px solid var(--slate-200);
+  font-size: 0.95rem;
+}
+
+.table th {
+  background: var(--blue-100);
+  color: var(--blue-700);
+  font-weight: 600;
+}
+
+.notice {
+  background: var(--blue-100);
+  border-left: 4px solid var(--blue-500);
+  padding: 1.2rem 1.5rem;
+  border-radius: 12px;
+  color: var(--slate-700);
+}
+
+@media (max-width: 720px) {
+  nav ul {
+    gap: 0.4rem;
+  }
+
+  .navbar {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .hero {
+    padding-top: 4rem;
+  }
+}


### PR DESCRIPTION
### Motivation
- Provide a complete set of static site pages for the PNSQC site using the layout and style of the existing `index.html` design.
- Consolidate shared design tokens, layout, and components into a single stylesheet to ensure consistent appearance across pages with only static content.
- Allow the generated static output to be committed by removing `dist` from the `.gitignore` so the `dist/` site can be versioned and reviewed.

### Description
- Added the static site output under `dist/` including `index.html`, `about.html`, `conference.html`, `program.html`, `attend.html`, `sponsors.html`, and `contact.html` which share a common header, footer, and content structure.
- Created a shared stylesheet at `dist/styles.css` with typography, color tokens, layout, and component styles (hero, cards, tables, callouts, responsive rules).
- Updated `.gitignore` to allow committing the `dist/` directory by removing the `dist` entry.
- Committed the new files to the repository so the static site output is tracked.

### Testing
- Launched a simple local static server with `python -m http.server 8000 --directory /workspace/website/dist` which started successfully. 
- Ran a Playwright script that navigated to `http://localhost:8000/index.html` and produced a screenshot artifact at `artifacts/pnsqc-home.png`, confirming the homepage renders as expected. 
- Performed repository checks (`git status`, `git add`, `git commit`) and the changes were committed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6979c7b9cb008333b3068f6dbbbb897e)