### PR TITLE
Windows build fix

### DIFF
--- a/build.mjs
+++ b/build.mjs
@@ -1,9 +1,10 @@
 #!/usr/bin/env node
 
 import { readFileSync, writeFileSync, statSync, readdirSync, cpSync, rmSync, existsSync } from 'fs';
-import { join, relative } from 'path';
+import path, { join, relative } from 'path';
+import { fileURLToPath } from 'url';
 
-const ROOT = new URL('.', import.meta.url).pathname;
+const ROOT = path.dirname(fileURLToPath(import.meta.url));
 const SRC = join(ROOT, 'src');
 const DIST = join(ROOT, 'dist');
 


### PR DESCRIPTION
Path resolution was not working for Windows, so needed to fix how it's derived. I think it should continue to work for macOS the way I've done it.