### PR TITLE
Input a <title> tag placeholder on every page for auto-injection from meta fields

### DIFF
--- a/site.config.json
+++ b/site.config.json
@@ -1,6 +1,6 @@
 {
-  "baseUrl": "https://example.com",
-  "siteName": "PNSQC — Pacific NW Software Quality Conference",
+  "baseUrl": "https://pnsqc.org",
+  "siteName": "PNSQC",
   "defaultDescription": "PNSQC is a nonprofit software quality conference built by the community, for the community. Join practitioners in the Pacific Northwest for talks, workshops, and networking.",
   "defaultOgImage": "/images/hero/hero-collaboration.png",
   "locale": "en_US"

--- a/src/404.html
+++ b/src/404.html
@@ -1,11 +1,12 @@
 <!-- meta
-title: 404 — Page Not Found | PNSQC
+title: 404 Page Not Found — PNSQC
 description: The page you requested could not be found. Return to the PNSQC homepage or browse current conference resources.
 og_image: /images/hero/hero-collaboration.png
 -->
 <!DOCTYPE html>
 <html lang="en">
 <head>
+  <title></title>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <link rel="stylesheet" href="/css/site.css">

--- a/src/about/board_organization/index.html
+++ b/src/about/board_organization/index.html
@@ -6,6 +6,7 @@ og_image: /images/hero/hero-collaboration.png
 <!DOCTYPE html>
 <html lang="en">
 <head>
+  <title></title>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <link rel="stylesheet" href="/css/site.css">

--- a/src/about/governance/cancellation-policy/index.html
+++ b/src/about/governance/cancellation-policy/index.html
@@ -6,6 +6,7 @@ og_image: /images/hero/hero-collaboration.png
 <!DOCTYPE html>
 <html lang="en">
 <head>
+  <title></title>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <link rel="stylesheet" href="/css/site.css">

--- a/src/about/governance/code-of-conduct/index.html
+++ b/src/about/governance/code-of-conduct/index.html
@@ -6,6 +6,7 @@ og_image: /images/hero/hero-collaboration.png
 <!DOCTYPE html>
 <html lang="en">
 <head>
+  <title></title>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta http-equiv="refresh" content="0; url=../../../docs/PNSQC_Code_of_Conduct_V1.1.pdf">

--- a/src/about/governance/conflict-of-interest-policy/index.html
+++ b/src/about/governance/conflict-of-interest-policy/index.html
@@ -6,6 +6,7 @@ og_image: /images/hero/hero-collaboration.png
 <!DOCTYPE html>
 <html lang="en">
 <head>
+  <title></title>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta http-equiv="refresh" content="0; url=../../../docs/PNSQC_Conflict_of_Interest_Policy_V2_09Mar2022.pdf">

--- a/src/about/governance/document-retention-policy/index.html
+++ b/src/about/governance/document-retention-policy/index.html
@@ -6,6 +6,7 @@ og_image: /images/hero/hero-collaboration.png
 <!DOCTYPE html>
 <html lang="en">
 <head>
+  <title></title>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta http-equiv="refresh" content="0; url=../../../docs/PNSQC_Documentation_Retention_Policy_V2_09Mar2022.pdf">

--- a/src/about/governance/financial-policy/index.html
+++ b/src/about/governance/financial-policy/index.html
@@ -6,6 +6,7 @@ og_image: /images/hero/hero-collaboration.png
 <!DOCTYPE html>
 <html lang="en">
 <head>
+  <title></title>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta http-equiv="refresh" content="0; url=../../../docs/PNSQC_Financial_Policy_Version_1_10Jan2022.pdf">

--- a/src/about/governance/generative-ai-policy/index.html
+++ b/src/about/governance/generative-ai-policy/index.html
@@ -6,6 +6,7 @@ og_image: /images/hero/hero-collaboration.png
 <!DOCTYPE html>
 <html lang="en">
 <head>
+  <title></title>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta http-equiv="refresh" content="0; url=../../../docs/PNSQC_Generative_AI_Policy.pdf">

--- a/src/about/governance/index.html
+++ b/src/about/governance/index.html
@@ -6,6 +6,7 @@ og_image: /images/hero/hero-collaboration.png
 <!DOCTYPE html>
 <html lang="en">
 <head>
+  <title></title>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <link rel="stylesheet" href="/css/site.css">

--- a/src/about/governance/privacy-compliance-policy/index.html
+++ b/src/about/governance/privacy-compliance-policy/index.html
@@ -6,6 +6,7 @@ og_image: /images/hero/hero-collaboration.png
 <!DOCTYPE html>
 <html lang="en">
 <head>
+  <title></title>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta http-equiv="refresh" content="0; url=../../../docs/Privacy_and_Regulatory_Compliance_Policy_v2.0_17May2022.pdf">

--- a/src/about/governance/whistle-blower-policy/index.html
+++ b/src/about/governance/whistle-blower-policy/index.html
@@ -6,6 +6,7 @@ og_image: /images/hero/hero-collaboration.png
 <!DOCTYPE html>
 <html lang="en">
 <head>
+  <title></title>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta http-equiv="refresh" content="0; url=../../../docs/Whistle_Blower_Policy_V1.1.pdf">

--- a/src/archive/proceedings/index.html
+++ b/src/archive/proceedings/index.html
@@ -1,11 +1,12 @@
 <!-- meta
-title: Proceedings (1983-2020) — PNSQC
-description: Browse archived PNSQC proceedings (1983-2020) PDFs.
+title: Proceedings (1983-2025) — PNSQC
+description: Browse archived PNSQC proceedings (1983-2025) PDFs.
 og_image: /images/hero/hero-collaboration.png
 -->
 <!DOCTYPE html>
 <html lang="en">
 <head>
+  <title></title>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <link rel="stylesheet" href="/css/site.css">

--- a/src/cfp/index.html
+++ b/src/cfp/index.html
@@ -1,11 +1,12 @@
 <!-- meta
-title: Call for Proposals — PNSQC 2026
+title: Call for Proposals — PNSQC
 description: Submit your proposal for PNSQC 2026. Share your expertise in software quality, testing, and related topics with the Pacific Northwest quality community.
 og_image: /images/hero/hero-collaboration.png
 -->
 <!DOCTYPE html>
 <html lang="en">
 <head>
+  <title></title>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <link rel="stylesheet" href="/css/site.css">

--- a/src/conference/2025/at-a-glance/index.html
+++ b/src/conference/2025/at-a-glance/index.html
@@ -6,6 +6,7 @@ og_image: /images/hero/hero-collaboration.png
 <!DOCTYPE html>
 <html lang="en">
 <head>
+  <title></title>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <link rel="stylesheet" href="/css/site.css">

--- a/src/conference/2026/author-resources/index.html
+++ b/src/conference/2026/author-resources/index.html
@@ -1,11 +1,12 @@
 <!-- meta
-title: Author Resources — PNSQC 2026 Conference
+title: Author Resources — PNSQC
 description: Deadlines, submission instructions, templates, and FAQs for PNSQC 2026 authors.
 og_image: /images/hero/hero-collaboration.png
 -->
 <!DOCTYPE html>
 <html lang="en">
 <head>
+  <title></title>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <link rel="stylesheet" href="/css/site.css">

--- a/src/conference/2026/venue/index.html
+++ b/src/conference/2026/venue/index.html
@@ -1,11 +1,12 @@
 <!-- meta
-title: Venue — PNSQC 2026 Conference
+title: Venue — PNSQC
 description: Venue, accommodations, and in-person event details for PNSQC 2026 in Portland, Oregon.
 og_image: /images/hero/hero-collaboration.png
 -->
 <!DOCTYPE html>
 <html lang="en">
 <head>
+  <title></title>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <link rel="stylesheet" href="/css/site.css">

--- a/src/index.html
+++ b/src/index.html
@@ -1,11 +1,12 @@
 <!-- meta
-title: PNSQC — Pacific NW Software Quality Conference
+title: Pacific Northwest Software Quality Conference — PNSQC
 description: PNSQC is a nonprofit software quality conference built by the community, for the community. Join practitioners in the Pacific Northwest for talks, workshops, and networking.
 og_image: /images/hero/hero-collaboration.png
 -->
 <!DOCTYPE html>
 <html lang="en">
 <head>
+  <title></title>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <link rel="stylesheet" href="/css/site.css">

--- a/src/sponsor/become-a-sponsor/index.html
+++ b/src/sponsor/become-a-sponsor/index.html
@@ -6,6 +6,7 @@ og_image: /images/hero/hero-collaboration.png
 <!DOCTYPE html>
 <html lang="en">
 <head>
+  <title></title>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <link rel="stylesheet" href="/css/site.css">

--- a/src/sponsor/sponsors/index.html
+++ b/src/sponsor/sponsors/index.html
@@ -6,6 +6,7 @@ og_image: /images/hero/hero-collaboration.png
 <!DOCTYPE html>
 <html lang="en">
 <head>
+  <title></title>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <link rel="stylesheet" href="/css/site.css">

--- a/src/volunteer/index.html
+++ b/src/volunteer/index.html
@@ -6,6 +6,7 @@ og_image: /images/hero/hero-collaboration.png
 <!DOCTYPE html>
 <html lang="en">
 <head>
+  <title></title>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <link rel="stylesheet" href="/css/site.css">


### PR DESCRIPTION
@helincao Looks like browser tab titles were broken because no `<title>` tag existed on any page. I put it on every page to be auto-filled.