### PR TITLE
Fix sitemap.xml and robots.txt files so they can be read by search engine crawlers

### DIFF
--- a/build.mjs
+++ b/build.mjs
@@ -142,7 +142,7 @@ function generateSitemap(files, config, targetDir) {
   const sitemapFiles = files.filter(f => relative(targetDir, f) !== '404.html');
   const urls = sitemapFiles.map(f => {
     const rel = relative(targetDir, f);
-    const urlPath = '/' + rel.replace(/index\.html$/, '').replace(/\.html$/, '');
+    const urlPath = '/' + rel.replaceAll('\\', '\/');
     const lastmod = statSync(f).mtime.toISOString().split('T')[0];
     return `  <url>\n    <loc>${config.baseUrl}${urlPath}</loc>\n    <lastmod>${lastmod}</lastmod>\n  </url>`;
   });

--- a/site.config.json
+++ b/site.config.json
@@ -1,7 +1,7 @@
 {
-  "baseUrl": "https://pnsqc.com",
+  "baseUrl": "https://pnsqc.org",
   "siteName": "PNSQC — Pacific NW Software Quality Conference",
   "defaultDescription": "PNSQC is a nonprofit software quality conference built by the community, for the community. Join practitioners in the Pacific Northwest for talks, workshops, and networking.",
-  "defaultOgImage": "/images/hero/hero-collaboration.png",
+  "defaultOgImage": "/images/brand/pnsqc-logo.jpg",
   "locale": "en_US"
 }


### PR DESCRIPTION
@helincao I think this is correct; I don't really understand why the `build.mjs` file was removing the `index.html` portion. Google specifically says [on this document](https://developers.google.com/search/docs/crawling-indexing/sitemaps/build-sitemap#general-guidelines) it needs the full, absolute path. It was also putting in backslashes instead of forward slashes.