### PR TITLE
Add events@pnsqc.org email to contact us page

### DIFF
--- a/src/about/contact/index.html
+++ b/src/about/contact/index.html
@@ -48,7 +48,11 @@ og_image: /images/hero/hero-collaboration.png
           <ul class="space-y-4 text-pnsqc-slate leading-relaxed">
             <li>
               <a class="text-pnsqc-gold hover:text-pnsqc-gold-light transition-colors font-semibold" href="mailto:program@pnsqc.org">program@pnsqc.org</a><br>
-              <span>Annual conference questions and inquiries</span>
+              <span>Event programming questions for conference/meetups</span>
+            </li>
+            <li>
+              <a class="text-pnsqc-gold hover:text-pnsqc-gold-light transition-colors font-semibold" href="mailto:events@pnsqc.org">events@pnsqc.org</a><br>
+              <span>Event registration assistance (including discounts/refunds)</span>
             </li>
             <li>
               <a class="text-pnsqc-gold hover:text-pnsqc-gold-light transition-colors font-semibold" href="mailto:sponsors@pnsqc.org">sponsors@pnsqc.org</a><br>

--- a/src/about/governance/cancellation-policy/index.html
+++ b/src/about/governance/cancellation-policy/index.html
@@ -69,7 +69,7 @@ og_image: /images/hero/hero-collaboration.png
                 <div>
                   <h3 class="text-xl font-semibold text-pnsqc-green mb-2">60+ Days Before Conference</h3>
                   <p class="text-pnsqc-slate">
-                    Registrations canceled 60 days prior to the conference will receive a full refund, although we prefer that you transfer the registration to someone else within your organization. For a cancelation code, please email <a href="mailto:program@pnsqc.org" class="text-pnsqc-gold hover:text-pnsqc-gold-light transition-colors">program@pnsqc.org</a>
+                    Registrations canceled 60 days prior to the conference will receive a full refund, although we prefer that you transfer the registration to someone else within your organization. For a cancelation code, please email <a href="mailto:events@pnsqc.org" class="text-pnsqc-gold hover:text-pnsqc-gold-light transition-colors">events@pnsqc.org</a>
                   </p>
                 </div>
               </div>
@@ -110,14 +110,14 @@ og_image: /images/hero/hero-collaboration.png
           <h2 class="text-2xl font-bold text-white mb-4">Questions or Concerns?</h2>
           <div class="p-6 bg-pnsqc-blue/10 border border-pnsqc-gold/30 rounded-lg">
             <p class="text-pnsqc-slate mb-3">
-              For questions or concerns, please contact our Program Committee at
+              For questions or concerns, please contact our Events team at
             </p>
-            <a href="mailto:program@pnsqc.org"
+            <a href="mailto:events@pnsqc.org"
                class="inline-flex items-center gap-2 text-pnsqc-gold hover:text-pnsqc-gold-light transition-colors text-lg font-medium">
               <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 8l7.89 5.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z"/>
               </svg>
-              program@pnsqc.org
+              events@pnsqc.org
             </a>
           </div>
         </div>


### PR DESCRIPTION
@helincao We'll need to separate out emails regarding actual event registration (ie. asking about discount codes and refunds), from our general programming inquiries. So I did that with a new "events@pnsqc.org" address.