### PR TITLE
Update 2026 workshops page with modal details

### DIFF
--- a/src/conference/2026/workshops/index.html
+++ b/src/conference/2026/workshops/index.html
@@ -1,6 +1,6 @@
 <!-- meta
 title: Workshops — PNSQC 2026 Conference
-description: PNSQC 2026 workshop announcements and registration details will be posted here.
+description: Explore all PNSQC 2026 workshops, including instructors, workshop summaries, and full details.
 og_image: /images/hero/hero-collaboration.png
 -->
 <!DOCTYPE html>
@@ -22,30 +22,281 @@ og_image: /images/hero/hero-collaboration.png
        WORKSHOPS PAGE CONTENT
        ============================================================ -->
   <section class="relative py-16">
-    <div class="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8">
-      <div class="mb-8">
+    <div class="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8">
+      <div class="mb-12">
         <p class="text-sm uppercase tracking-[0.2em] text-pnsqc-cyan mb-3">PNSQC 2026 Conference</p>
         <h1 class="text-4xl sm:text-5xl font-bold bg-gradient-to-r from-pnsqc-gold to-pnsqc-gold-light bg-clip-text text-transparent mb-4">
           Workshops
         </h1>
-        <p class="text-pnsqc-slate text-lg leading-relaxed">
-          Hands-on and deep-dive workshop offerings for PNSQC 2026 will be listed here.
+        <p class="text-pnsqc-slate text-lg leading-relaxed max-w-4xl">
+          Hands-on workshop sessions designed for quality engineers, testers, and leaders. Use Read More for full workshop details and speaker bios.
         </p>
       </div>
 
-      <div class="rounded-2xl border border-pnsqc-gold/20 bg-pnsqc-blue/10 p-8">
-        <p class="text-xl text-white font-medium">Watch this space for announcements...</p>
-        <p class="mt-4 text-pnsqc-slate leading-relaxed">
-          We will publish workshop topics, instructors, formats, and registration details as they are confirmed.
-        </p>
+      <div class="grid gap-6 md:grid-cols-2">
+        <article class="rounded-2xl border border-pnsqc-gold/20 bg-pnsqc-blue/10 p-6">
+          <div class="flex items-start gap-4">
+            <img src="/images/brand/pnsqc-logo.jpg" alt="Workshop speaker avatar" class="w-14 h-14 rounded-lg object-cover ring-2 ring-pnsqc-gold/30">
+            <div>
+              <h2 class="text-xl font-semibold text-white">AI Agentic Testing: AI Augmented Testing</h2>
+              <p class="text-pnsqc-cyan mt-1">Jonathon Wright</p>
+            </div>
+          </div>
+          <p class="mt-4 text-pnsqc-slate">Move beyond AI-assisted testing and learn to deploy autonomous agents that can verify and validate AI systems independently.</p>
+          <button type="button" class="inline-flex items-center gap-1.5 mt-4 text-xs font-semibold text-pnsqc-gold px-2.5 py-1.5 rounded bg-pnsqc-gold/10 hover:bg-pnsqc-gold/15 hover:text-pnsqc-gold-light transition-colors" data-track-modal-open="workshop-modal-template-1" data-track-modal-title="AI Agentic Testing: AI Augmented Testing" data-track-modal-label="Workshop - Jonathon Wright">Read More<svg class="h-3.5 w-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"/></svg></button>
+        </article>
+
+        <article class="rounded-2xl border border-pnsqc-gold/20 bg-pnsqc-blue/10 p-6">
+          <div class="flex items-start gap-4">
+            <img src="/images/brand/pnsqc-logo.jpg" alt="Workshop speaker avatar" class="w-14 h-14 rounded-lg object-cover ring-2 ring-pnsqc-gold/30">
+            <div>
+              <h2 class="text-xl font-semibold text-white">A Quality Engineering Introduction to AI and Machine Learning</h2>
+              <p class="text-pnsqc-cyan mt-1">Tariq King</p>
+            </div>
+          </div>
+          <p class="mt-4 text-pnsqc-slate">Build the cross-disciplinary knowledge you need to test the unpredictable, adaptive behavior of modern AI and ML systems.</p>
+          <button type="button" class="inline-flex items-center gap-1.5 mt-4 text-xs font-semibold text-pnsqc-gold px-2.5 py-1.5 rounded bg-pnsqc-gold/10 hover:bg-pnsqc-gold/15 hover:text-pnsqc-gold-light transition-colors" data-track-modal-open="workshop-modal-template-2" data-track-modal-title="A Quality Engineering Introduction to AI and Machine Learning" data-track-modal-label="Workshop - Tariq King">Read More<svg class="h-3.5 w-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"/></svg></button>
+        </article>
+
+        <article class="rounded-2xl border border-pnsqc-gold/20 bg-pnsqc-blue/10 p-6">
+          <div class="flex items-start gap-4">
+            <img src="/images/brand/pnsqc-logo.jpg" alt="Workshop speaker avatar" class="w-14 h-14 rounded-lg object-cover ring-2 ring-pnsqc-gold/30">
+            <div>
+              <h2 class="text-xl font-semibold text-white">Social Software Testing Approaches</h2>
+              <p class="text-pnsqc-cyan mt-1">Maaret Pyhäjärvi</p>
+            </div>
+          </div>
+          <p class="mt-4 text-pnsqc-slate">Discover how pair testing, ensemble testing, and bug bashes unlock insights and skills you simply cannot get working alone.</p>
+          <button type="button" class="inline-flex items-center gap-1.5 mt-4 text-xs font-semibold text-pnsqc-gold px-2.5 py-1.5 rounded bg-pnsqc-gold/10 hover:bg-pnsqc-gold/15 hover:text-pnsqc-gold-light transition-colors" data-track-modal-open="workshop-modal-template-7" data-track-modal-title="Social Software Testing Approaches" data-track-modal-label="Workshop - Maaret Pyhajarvi">Read More<svg class="h-3.5 w-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"/></svg></button>
+        </article>
+
+        <article class="rounded-2xl border border-pnsqc-gold/20 bg-pnsqc-blue/10 p-6">
+          <div class="flex items-start gap-4">
+            <img src="/images/brand/pnsqc-logo.jpg" alt="Workshop speaker avatar" class="w-14 h-14 rounded-lg object-cover ring-2 ring-pnsqc-gold/30">
+            <div>
+              <h2 class="text-xl font-semibold text-white">Testing the Next Generation of AI-Based Software</h2>
+              <p class="text-pnsqc-cyan mt-1">Jason Arbon</p>
+            </div>
+          </div>
+          <p class="mt-4 text-pnsqc-slate">Learn practical strategies to test software that is no longer deterministic, static, or confined to predictable behavior.</p>
+          <button type="button" class="inline-flex items-center gap-1.5 mt-4 text-xs font-semibold text-pnsqc-gold px-2.5 py-1.5 rounded bg-pnsqc-gold/10 hover:bg-pnsqc-gold/15 hover:text-pnsqc-gold-light transition-colors" data-track-modal-open="workshop-modal-template-4" data-track-modal-title="Testing the Next Generation of AI-Based Software" data-track-modal-label="Workshop - Jason Arbon">Read More<svg class="h-3.5 w-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"/></svg></button>
+        </article>
+
+        <article class="rounded-2xl border border-pnsqc-gold/20 bg-pnsqc-blue/10 p-6">
+          <div class="flex items-start gap-4">
+            <img src="/images/brand/pnsqc-logo.jpg" alt="Workshop speaker avatar" class="w-14 h-14 rounded-lg object-cover ring-2 ring-pnsqc-gold/30">
+            <div>
+              <h2 class="text-xl font-semibold text-white">Using Models to Define Test Plans</h2>
+              <p class="text-pnsqc-cyan mt-1">Wayne Roseberry</p>
+            </div>
+          </div>
+          <p class="mt-4 text-pnsqc-slate">Develop effective, lightweight test plans faster using modeling techniques that surface risks and align your whole team.</p>
+          <button type="button" class="inline-flex items-center gap-1.5 mt-4 text-xs font-semibold text-pnsqc-gold px-2.5 py-1.5 rounded bg-pnsqc-gold/10 hover:bg-pnsqc-gold/15 hover:text-pnsqc-gold-light transition-colors" data-track-modal-open="workshop-modal-template-5" data-track-modal-title="Using Models to Define Test Plans" data-track-modal-label="Workshop - Wayne Roseberry">Read More<svg class="h-3.5 w-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"/></svg></button>
+        </article>
+
+        <article class="rounded-2xl border border-pnsqc-gold/20 bg-pnsqc-blue/10 p-6">
+          <div class="flex items-start gap-4">
+            <img src="/images/brand/pnsqc-logo.jpg" alt="Workshop speaker avatar" class="w-14 h-14 rounded-lg object-cover ring-2 ring-pnsqc-gold/30">
+            <div>
+              <h2 class="text-xl font-semibold text-white">Integrate The Model Context Protocol (MCP) into your workflow</h2>
+              <p class="text-pnsqc-cyan mt-1">Joe Petsche</p>
+            </div>
+          </div>
+          <p class="mt-4 text-pnsqc-slate">Harness the power of MCP to connect AI systems with your tools and dramatically expand your test coverage.</p>
+          <button type="button" class="inline-flex items-center gap-1.5 mt-4 text-xs font-semibold text-pnsqc-gold px-2.5 py-1.5 rounded bg-pnsqc-gold/10 hover:bg-pnsqc-gold/15 hover:text-pnsqc-gold-light transition-colors" data-track-modal-open="workshop-modal-template-6" data-track-modal-title="Integrate The Model Context Protocol (MCP) into your workflow" data-track-modal-label="Workshop - Joe Petsche">Read More<svg class="h-3.5 w-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"/></svg></button>
+        </article>
+
+        <article class="rounded-2xl border border-pnsqc-gold/20 bg-pnsqc-blue/10 p-6">
+          <div class="flex items-start gap-4">
+            <img src="/images/brand/pnsqc-logo.jpg" alt="Workshop speaker avatar" class="w-14 h-14 rounded-lg object-cover ring-2 ring-pnsqc-gold/30">
+            <div>
+              <h2 class="text-xl font-semibold text-white">Testing Beyond Your Laptop with GitHub Actions</h2>
+              <p class="text-pnsqc-cyan mt-1">Juan de Dios Delgado Bernal</p>
+            </div>
+          </div>
+          <p class="mt-4 text-pnsqc-slate">Stop relying on "works on my machine" and start shipping confidence with automated workflows you build from scratch.</p>
+          <button type="button" class="inline-flex items-center gap-1.5 mt-4 text-xs font-semibold text-pnsqc-gold px-2.5 py-1.5 rounded bg-pnsqc-gold/10 hover:bg-pnsqc-gold/15 hover:text-pnsqc-gold-light transition-colors" data-track-modal-open="workshop-modal-template-3" data-track-modal-title="Testing Beyond Your Laptop with GitHub Actions" data-track-modal-label="Workshop - Juan de Dios Delgado Bernal">Read More<svg class="h-3.5 w-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"/></svg></button>
+        </article>
+
+        <article class="rounded-2xl border border-pnsqc-gold/20 bg-pnsqc-blue/10 p-6">
+          <div class="flex items-start gap-4">
+            <img src="/images/brand/pnsqc-logo.jpg" alt="Workshop speaker avatar" class="w-14 h-14 rounded-lg object-cover ring-2 ring-pnsqc-gold/30">
+            <div>
+              <h2 class="text-xl font-semibold text-white">Quality Leadership in 2026: A Managers' Forum on Today's Hardest Problems</h2>
+              <p class="text-pnsqc-cyan mt-1">Philip Lew</p>
+            </div>
+          </div>
+          <p class="mt-4 text-pnsqc-slate">Bring your real challenges and leave with peer-tested strategies for leading quality teams in an AI-driven world.</p>
+          <button type="button" class="inline-flex items-center gap-1.5 mt-4 text-xs font-semibold text-pnsqc-gold px-2.5 py-1.5 rounded bg-pnsqc-gold/10 hover:bg-pnsqc-gold/15 hover:text-pnsqc-gold-light transition-colors" data-track-modal-open="workshop-modal-template-8" data-track-modal-title="Quality Leadership in 2026: A Managers' Forum on Today's Hardest Problems" data-track-modal-label="Workshop - Philip Lew">Read More<svg class="h-3.5 w-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"/></svg></button>
+        </article>
       </div>
     </div>
   </section>
+
+  <div class="fixed inset-0 z-50 hidden" data-track-modal>
+    <div class="absolute inset-0 bg-pnsqc-navy/85 backdrop-blur-sm" data-track-modal-backdrop></div>
+
+    <div class="relative z-10 flex min-h-full items-center justify-center p-4 sm:p-6">
+      <div class="w-full max-w-3xl rounded-2xl border border-pnsqc-gold/25 bg-pnsqc-navy shadow-2xl" role="dialog" aria-modal="true" aria-labelledby="workshop-modal-title" data-track-modal-panel>
+        <div class="flex items-start justify-between border-b border-white/10 px-5 py-4 sm:px-6">
+          <div>
+            <p class="text-xs font-semibold uppercase tracking-widest text-pnsqc-gold/80" data-track-modal-label>Workshop</p>
+            <h3 id="workshop-modal-title" class="mt-1 text-lg sm:text-xl font-bold text-white" data-track-modal-title>Workshop Details</h3>
+          </div>
+          <button type="button" class="rounded-lg border border-white/10 p-2 text-pnsqc-slate hover:text-white hover:border-white/25 transition-colors" aria-label="Close workshop details" data-track-modal-close>
+            <svg class="h-5 w-5" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"/></svg>
+          </button>
+        </div>
+        <div class="max-h-[75vh] overflow-y-auto px-5 py-5 sm:px-6 sm:py-6" data-track-modal-body></div>
+      </div>
+    </div>
+  </div>
+
+  <template id="workshop-modal-template-1">
+    <div class="space-y-5 text-sm leading-7 text-pnsqc-slate">
+      <p><em>Move beyond AI-assisted testing and learn to deploy autonomous agents that can verify and validate AI systems independently.</em></p>
+      <p>The fast spread of autonomous agentic AI systems has created an unprecedented crisis of trust because traditional testing methods fail to solve the software quality problems which result from this transformation. Organizations need to address their 20-30% value gap between AI system capabilities and their current organizational readiness because 8 out of 10 businesses will need AI governance solutions during the next four years.</p>
+      <p>The workshop provides QA professionals and testers and developers and quality engineers with functional methods to achieve AI Assurance which involves verifying the trustworthiness and reliability and compliance of systems that use artificial intelligence. The program will teach participants to transition from AI-assisted testing methods which use AI tools with human involvement to AI-based testing which uses autonomous agents to maintain quality independently.</p>
+      <p>The program includes practical activities and live presentations and actual examples from Fortune 500 organizations which demonstrate how to apply new concepts. The program includes Computer Use Agents (CUA) and Large Vision Models (LLaVA) and Large Action Models (LAM) and Model Context Protocol (MCP) and Agent-to-Agent (A2A) communication and necessary governance frameworks for ISO 42001 compliance.</p>
+      <p>By the end of the workshop, participants will be able to:</p>
+      <ul class="list-disc pl-6 space-y-1">
+        <li>Master AI Assurance Principles: Understand the fundamental shift from traditional QA to AI assurance, including the core trust attributes that define trustworthy AI systems.</li>
+        <li>Implement AI Governance Frameworks: Apply practical governance frameworks aligned with ISO 42001, NIST AI RMF (inc. GCR 26-69), and EU AI Act requirements for compliant AI testing programs.</li>
+        <li>Execute Vibe Testing Techniques: Leverage prompt engineering and AI-augmented approaches to dramatically accelerate test design and execution while maintaining quality standards.</li>
+        <li>Deploy AI-Agentic Testing: Configure and utilize autonomous testing agents including Computer Use Agents, Large Action Models, and multi-agent orchestration frameworks.</li>
+        <li>Evaluate AI Systems by Modality: Apply appropriate testing frameworks for generative AI, RAG systems, and agentic AI based on their unique failure modes and quality attributes.</li>
+        <li>Establish Continuous AI Quality: Implement production monitoring, drift detection, and observability practices for ongoing AI system validation.</li>
+      </ul>
+      <h4 class="text-xs font-semibold uppercase tracking-widest text-pnsqc-gold">Who Should Attend</h4>
+      <ul class="list-disc pl-6 space-y-1">
+        <li>Software testers and SDETs</li>
+        <li>Quality engineers and test leads</li>
+        <li>Developers working with AI-assisted tools</li>
+        <li>Engineering managers and technical product leaders</li>
+        <li>Anyone concerned about the future of testing in AI-augmented teams</li>
+      </ul>
+      <h4 class="text-xs font-semibold uppercase tracking-widest text-pnsqc-gold">Bio</h4>
+      <p>Jonathan Wright is, and has been, in no particular order: Chief AI Officer, Chair of World Agentic AI + AutomationSTAR (2026), a Best-Selling Author on AI (2022), an International Keynote Speaker, a TED Speaker on AI (2017), a BCS Fellow &amp; Committee and a Podcast Host and Influencer.  His LinkedIn URL is <a class="text-pnsqc-cyan hover:text-pnsqc-gold" href="https://www.linkedin.com/in/automation" target="_blank" rel="noopener noreferrer">https://www.linkedin.com/in/automation</a></p>
+    </div>
+  </template>
+  <template id="workshop-modal-template-2">
+    <div class="space-y-5 text-sm leading-7 text-pnsqc-slate">
+      <p><em>Build the cross-disciplinary knowledge you need to test the unpredictable, adaptive behavior of modern AI and ML systems.</em></p>
+      <p>Although there are several controversies and misunderstandings surrounding AI and machine learning, one thing is apparent — people have quality concerns about the safety, reliability, and trustworthiness of these types of systems. Not only are ML-based systems shrouded in mystery due to their largely black-box nature, they also tend to be unpredictable since they can adapt, learn, and generate new things at runtime. Validating ML systems is challenging and requires a cross-section of knowledge, skills, and experience from areas such as mathematics, data science, software engineering, cyber-security, and operations.  Join Tariq King as he gives you a quality engineering introduction to testing AI and machine learning. You'll learn AI and ML fundamentals, including how intelligent agents are modeled, trained and developed. Tariq then dives into approaches for validating ML models offline, prior to release, and online, continuously post-deployment. Engage with other participants to develop and execute test plans for ML-based systems, and experience the practical issues around building and testing AI-infused and AI native applications first-hand.</p>
+      <h4 class="text-xs font-semibold uppercase tracking-widest text-pnsqc-gold">Bio</h4>
+      <p>Tariq King is a recognized thought-leader in software testing, engineering, DevOps, and AI/ML. He is currently the CEO and Head of Test IO, an EPAM company. Tariq has over fifteen years' professional experience in the software industry, and has formerly held positions including VP of Product-Services, Chief Scientist, Head of Quality, Quality Engineering Director, Software Engineering Manager, and Principal Architect.</p>
+      <p>He holds Ph.D. and M.S. degrees in Computer Science from Florida International University, and a B.S. in Computer Science from Florida Tech. He has published over 40 research articles in peer-reviewed IEEE and ACM journals, conferences, and workshops, and has written book chapters and technical reports for Springer, O'Reilly, Capgemini, Sogeti, IGI Global, and more. Tariq has been an international keynote speaker and trainer at leading software conferences in industry and academia, and serves on multiple conference boards and program committees.</p>
+      <p>Outside of work, Tariq is an electric car enthusiast who enjoys playing video games and traveling the world with his wife and kids.</p>
+    </div>
+  </template>
+  <template id="workshop-modal-template-3">
+    <div class="space-y-5 text-sm leading-7 text-pnsqc-slate">
+      <p><em>Stop relying on "works on my machine" and start shipping confidence with automated workflows you build from scratch.</em></p>
+      <p>Many QA and engineering teams validate code locally, which is often where the familiar “it works on my machine” problem appears. In this hands-on workshop, participants will explore how to move testing beyond their laptops by building an automated workflow using GitHub Actions. Attendees will create workflows from scratch, configure automated checks (such as linting and testing), and walk away with a practical workflow they can adapt to their own projects.</p>
+      <p>Learning Objectives</p>
+      <ul class="list-disc pl-6 space-y-1">
+        <li>By the end of this workshop, participants will be able to:</li>
+        <li>Set up a GitHub repository and define a basic workflow structure, including triggers, jobs, and steps.</li>
+        <li>Add and run automated checks (such as linting and testing) within a shared workflow.</li>
+        <li>Practice the complete workflow by creating a branch, opening a pull request, pushing changes, and observing automated checks in action.</li>
+      </ul>
+      <h4 class="text-xs font-semibold uppercase tracking-widest text-pnsqc-gold">Bio</h4>
+      <p>Juan is a Senior QA Automation Engineer with 10+ years of experience building and executing automation strategies for web, mobile and IoT products.  He has experience with Python, Selenium, API testing and CI/CD pipelines.  Experienced working with US-based distributed teams and delivering high-quality releases in agile environments, he enjoys staying technical, building automation frameworks and contributing directly to product quality.</p>
+    </div>
+  </template>
+  <template id="workshop-modal-template-4">
+    <div class="space-y-5 text-sm leading-7 text-pnsqc-slate">
+      <p><em>Learn practical strategies to test software that is no longer deterministic, static, or confined to predictable behavior.</em></p>
+      <p>Software systems built with AI are no longer static, deterministic, or confined to fixed interfaces. The next generation of AI-based software is increasingly personalized, adaptive, and open-ended—driven by dynamic user interfaces, evolving APIs, probabilistic algorithms, and generative experiences that change behavior at runtime. These systems often operate in open worlds, interact with humans in natural language, and, in emerging cases, extend into embodied systems such as humanoid robotics. Traditional testing approaches, designed for predictable inputs and repeatable outputs, are not sufficient to assure quality, safety, and trust in this new class of software.</p>
+      <p>This half-day workshop explores how quality engineering must evolve to test AI-based software of the future. Participants will learn practical strategies for testing personalized AI behavior, dynamic interfaces, AI-driven APIs, and generative systems where “correctness” varies by context and user. The workshop will cover techniques for testing open-world generative experiences, detecting subtle failure modes where AI appears correct but is wrong, and validating systems that continuously learn or adapt over time. The session also examines how these testing challenges extend to physical and semi-autonomous systems, including humanoid and robotic interfaces, where software quality directly affects real-world outcomes.</p>
+      <p>The workshop emphasizes hands-on, practical approaches grounded in real production experience, focusing on how to design test strategies, evaluation criteria, and feedback loops that scale with modern AI systems. Attendees will leave with a clearer understanding of how to evolve their testing practices to support the next wave of AI-driven software with confidence.</p>
+      <p>Preparation &amp; Requirements</p>
+      <p>Participants should bring:</p>
+      <ul class="list-disc pl-6 space-y-1">
+        <li>A laptop</li>
+        <li>Access to a paid, commercial frontier AI model (such as OpenAI, Anthropic Claude, or Google Gemini)</li>
+      </ul>
+      <p>No prior experience with AI testing frameworks is required, but familiarity with software testing concepts is recommended.</p>
+      <h4 class="text-xs font-semibold uppercase tracking-widest text-pnsqc-gold">Bio</h4>
+      <p>Jason Arbon has spent his career working at the cutting edge of the most complex and demanding software testing challenges in the industry. He has led and contributed to testing efforts for large-scale, high-risk systems including Microsoft Windows, Bing, Google Chrome, and Google Search—environments where correctness, relevance, performance, and user trust must operate at global scale and under constant change.</p>
+      <p>Jason was among the earliest practitioners applying AI to software testing, helping pioneer AI-driven quality approaches at Applause and later founding Test.ai, an AI-first testing company funded by Google. At Test.ai, he focused on using machine learning to test dynamic, user-facing systems where traditional scripted testing failed. Today, as founder and CEO of Testers.AI, Jason continues to push the boundaries of quality engineering by building AI-driven testing systems that evaluate modern software across personalization, generative experiences, accessibility, trust, and real-world user behavior.</p>
+      <p>Throughout his career, Jason has consistently worked where testing is hardest—at scale, under uncertainty, and ahead of established best practices—making him uniquely qualified to address the challenges of testing the next generation of AI-based software.</p>
+    </div>
+  </template>
+  <template id="workshop-modal-template-5">
+    <div class="space-y-5 text-sm leading-7 text-pnsqc-slate">
+      <p><em>Develop effective, lightweight test plans faster using modeling techniques that surface risks and align your whole team.</em></p>
+      <p>Learn how to take an application, define it using models, and from there build your test ideas. This will be a hands-on workshop. You will learn some of the basic ideas of how to use models to represent lots of ideas with very little effort, how to re-use those models across different test problems, and how to change the type of model based on the kind of problem you want to cover.</p>
+      <p>We will also discuss using modeling to separate systems into different behaviors and components, and how to integrate the model into the larger system.  We will also address how model-based test plans can be used with AI.</p>
+      <p>The emphasis is on collaboration: each stage includes structured review points with developers and other testers to uncover gaps, ambiguities, and hidden risks early.</p>
+      <p>Key topics include:</p>
+      <ul class="list-disc pl-6 space-y-1">
+        <li>Rapidly outlining features and sub-features</li>
+        <li>Identifying and reviewing common testing concerns (security, performance, accessibility, integration, etc.)</li>
+        <li>Writing and prioritizing product requirements without over-specifying</li>
+        <li>Turning requirements into meaningful test ideas</li>
+        <li>Using test planning as a tool for discovery, communication, and risk identification—not just documentation</li>
+        <li>Knowing when to stop planning and when deeper test case design is actually worth the effort</li>
+      </ul>
+      <p>By the end of the workshop, attendees will have a “good enough” test plan skeleton they can take straight into conversations with stakeholders—and a repeatable technique they can apply immediately on real projects.</p>
+      <p>Who it's for: Testers, QA engineers, software engineers, and quality leaders who want faster, more effective test planning without bureaucracy.</p>
+      <p>Takeaway: A practical, collaborative method for test planning that improves understanding, surfaces risks early, and keeps testing aligned with what actually matters.</p>
+      <h4 class="text-xs font-semibold uppercase tracking-widest text-pnsqc-gold">Bio</h4>
+      <p>Wayne is currently an SDET for Ford. In the past he was an engineer for Microsoft. He is also a notable author and speaker on software quality and communication.  Wayne's LinkedIn URL is <a class="text-pnsqc-cyan hover:text-pnsqc-gold" href="https://www.linkedin.com/in/wayneroseberry/" target="_blank" rel="noopener noreferrer">https://www.linkedin.com/in/wayneroseberry/</a></p>
+    </div>
+  </template>
+  <template id="workshop-modal-template-6">
+    <div class="space-y-5 text-sm leading-7 text-pnsqc-slate">
+      <p><em>Harness the power of MCP to connect AI systems with your tools and dramatically expand your test coverage.</em></p>
+      <p>The Model Context Protocol (MCP) defines a standardized framework for integrating AI systems with external data sources and tools.  MCP enables developers to expose their data via MCP servers or to develop AI applications—referred to as MCP clients—that connect to these servers.</p>
+      <p>In this workshop Joe presents an overview of using this AI-driven methodology to accelerate the testing process and enhance test coverage by identifying and addressing edge cases that manual testing might overlook.</p>
+      <h4 class="text-xs font-semibold uppercase tracking-widest text-pnsqc-gold">Bio</h4>
+      <p>Joe has been coming to PNSQC for many years. An engaging speaker, he's excited to share the advances of using AI for API testing. Joe's LinkedIn profile is <a class="text-pnsqc-cyan hover:text-pnsqc-gold" href="https://www.linkedin.com/in/joepetsche/" target="_blank" rel="noopener noreferrer">https://www.linkedin.com/in/joepetsche/</a></p>
+    </div>
+  </template>
+  <template id="workshop-modal-template-7">
+    <div class="space-y-5 text-sm leading-7 text-pnsqc-slate">
+      <p><em>Discover how pair testing, ensemble testing, and bug bashes unlock insights and skills you simply can't get working alone.</em></p>
+      <p>Cross-functional teams have team members with specialized in-depth skills. Collaboration between team members has a significant impact on the team's ability to deliver value efficiently. Software teams are well aware of the need for their developers, testers, product owners, and other team members to collaborate.</p>
+      <p>Product backlog refinement, 3-amigos sessions and daily meetings create space for sharing planning of the work, but for much of the rest of the time, people are hunched over their own keyboards and screens, working on their own tasks. Even if developers work with each other during pair programming and code review sessions, testers often work on their own.</p>
+      <p>In this tutorial, we learn approaches involving a more social aspect that teams can adopt in order to work together and improve their testing, as well as work better with developers. We experience and learn about: Traditional and Strong-style pair testing-Ensemble testing and Ensemble Programming-Bug bash.  Why does the social way of doing the work make sense?</p>
+      <p>Software development is not about getting the most out of us, but the best out of us -avoiding the ping pong, creating ideas we would not generate alone, and sharpening our skills. We don't know what we don't know but can recognize it in the context of doing it.</p>
+      <p>In software development, those who learn the fastest do best. In addition to learning within the team, we can extend from learning within the team to the community: testing tours applying these approaches give you hands-on experiences working with others even in other companies.</p>
+      <p>This is a hands-on course, where we experience combinations of four social software testing approaches with three testing tasks: one we pair on, one we ensemble on, and one we do a bug bash on. You learn to successfully set up each of the activities, and recognize how to prepare, facilitate and summarize sessions for a good collaboration experience.</p>
+      <p><strong>PLEASE NOTE</strong>: Attendees will be working in pairs, and there will be some group work. Attendees will require 1 laptop between two people. No software downloads required.</p>
+      <h4 class="text-xs font-semibold uppercase tracking-widest text-pnsqc-gold">Bio</h4>
+      <p>Maaret Pyhäjärvi is a Tester Extraordinaire and Director of AI-Enhanced Application Testing at CGI. A practitioner, change agent, and tester of products and organizations, she brings a rare combination of exploratory testing expertise, polyglot programming, and strategic quality leadership to every context she works in. Speaker, author, mentor, and conference designer, Maaret has a strong theoretical background through research and teaching in software testing — and a track record of delivering on time, with quality.</p>
+      <p>A passionate advocate for pair and ensemble testing, she believes the fastest-learning teams are the highest-performing teams, and that the best insights emerge from working together rather than in isolation. Maaret specializes in combining hands-on craft with strategic quality management and teaching others what she does — making her the ideal guide for this exploration of social software testing approaches.</p>
+    </div>
+  </template>
+  <template id="workshop-modal-template-8">
+    <div class="space-y-5 text-sm leading-7 text-pnsqc-slate">
+      <p><em>Managing quality in 2026 looks very different than it did a decade ago.</em></p>
+      <p>Managers today are navigating AI-assisted development, autonomous systems, distributed teams, faster delivery expectations, shifting accountability models, and rising risk exposure—all while being expected to move faster and deliver more with fewer constraints.</p>
+      <p>This workshop revives and modernizes a successful managers' forum format from earlier PNSQC-era leadership sessions: a facilitated, peer-driven discussion where managers bring their real challenges, share what's working (and what isn't), and collectively explore emerging solutions.</p>
+      <p>Rather than offering a set of pre-packaged “best practices,” this workshop creates a space for honest, experience-based conversation among leaders who are facing similar problems. Participants will surface the issues keeping them up at night, cluster shared themes, and engage in structured small-group problem-solving to exchange practical insights.</p>
+      <p>This session emphasizes real-world experience over theory, peer learning over lectures, and sense-making over simplistic answers—because many of today's quality leadership challenges do not yet have settled playbooks.</p>
+      <p>Takeaways include:</p>
+      <ul class="list-disc pl-6 space-y-1">
+        <li>Managing quality and accountability when AI systems influence outcome</li>
+        <li>Measuring quality without slowing teams down</li>
+        <li>Balancing speed, autonomy, governance, and risk</li>
+        <li>Making decisions when outcomes are uncertain or non-deterministic</li>
+        <li>Aligning executives, product leaders, and engineering around quality strategy</li>
+        <li>Preventing burnout while maintaining quality and delivery expectations</li>
+        <li>Defining what “good enough” means in modern software and intelligent systems</li>
+      </ul>
+      <h4 class="text-xs font-semibold uppercase tracking-widest text-pnsqc-gold">Bio</h4>
+      <p>After working in various management and technical positions in software development and product management, Philip Lew leads XBOSoft's (<a class="text-pnsqc-cyan hover:text-pnsqc-gold" href="https://xbosoft.com" target="_blank" rel="noopener noreferrer">xbosoft.com</a>) direction and strategy as CEO. His Ph.D. research in software quality and usability resulted in several IEEE and ACM journal publications and in various trade journals as well. A speaker at numerous trade and academic conferences, he has worked with hundreds of organizations to assess the quality of their software, examine software quality processes, and set forth measurement plans to improve software quality using systematic methods. Find out more about Philip at <a class="text-pnsqc-cyan hover:text-pnsqc-gold" href="https://xbosoft.com" target="_blank" rel="noopener noreferrer">xbosoft.com</a>.</p>
+    </div>
+  </template>
 
   <!-- ============================================================
        FOOTER (from _partials/footer.html)
        ============================================================ -->
   <footer></footer>
 
+  <script src="/js/track-details-modal.js" defer></script>
 </body>
 </html>
+


### PR DESCRIPTION
## Summary
This PR implements issue #53 by replacing the placeholder workshops page with complete 2026 workshop content and in-page workshop details.

### What changed
- Updated `/conference/2026/workshops/` to display all 8 workshops with:
  - workshop title
  - workshop leader
  - workshop tagline
  - avatar/headshot placeholder using the PNSQC orange logo image
- Replaced per-workshop detail pages with in-page `Read More` modal popups on the workshops page.
- Implemented modal behavior using the same pattern as the homepage track modals (`track-details-modal.js`).
- Added full workshop detail content in modal templates, using issue-provided text and preserving formatting (italics + bullet lists).
- Converted workshop-related URLs in details into clickable hyperlinks.
- Swapped the positions of Juan de Dios Delgado Bernal and Maaret Pyhäjärvi workshop cards per follow-up request.
- Restored header/footer partial markers on the workshops page so build-time partial injection works correctly.
- Fixed text encoding/mojibake artifacts in workshop content and normalized problematic apostrophe characters to avoid editor warnings.

## Validation
- `npm run build` passes locally.
- Verified generated `dist/conference/2026/workshops/index.html` includes:
  - injected header/footer
  - workshop cards
  - modal triggers + templates

Closes #53.