### PR TITLE
Fix browser-specific (Firefox) issue with large workshop icons

### DIFF
--- a/src/conference/2026/workshops/index.html
+++ b/src/conference/2026/workshops/index.html
@@ -36,7 +36,7 @@ og_image: /images/hero/hero-collaboration.png
       <div class="grid gap-6 md:grid-cols-2">
         <article class="rounded-2xl border border-pnsqc-gold/20 bg-pnsqc-blue/10 p-6">
           <div class="flex items-start gap-4">
-            <img src="/images/brand/pnsqc-logo.jpg" alt="Workshop speaker avatar" class="w-14 h-14 rounded-lg object-cover ring-2 ring-pnsqc-gold/30">
+            <img src="/images/brand/pnsqc-logo.jpg" alt="Workshop speaker avatar" class="w-12 h-12 shrink-0 rounded-lg object-cover ring-2 ring-pnsqc-gold/30">
             <div>
               <h2 class="text-xl font-semibold text-white">AI Agentic Testing: AI Augmented Testing</h2>
               <p class="text-pnsqc-cyan mt-1">Jonathon Wright</p>
@@ -48,7 +48,7 @@ og_image: /images/hero/hero-collaboration.png
 
         <article class="rounded-2xl border border-pnsqc-gold/20 bg-pnsqc-blue/10 p-6">
           <div class="flex items-start gap-4">
-            <img src="/images/brand/pnsqc-logo.jpg" alt="Workshop speaker avatar" class="w-14 h-14 rounded-lg object-cover ring-2 ring-pnsqc-gold/30">
+            <img src="/images/brand/pnsqc-logo.jpg" alt="Workshop speaker avatar" class="w-12 h-12 shrink-0 rounded-lg object-cover ring-2 ring-pnsqc-gold/30">
             <div>
               <h2 class="text-xl font-semibold text-white">A Quality Engineering Introduction to AI and Machine Learning</h2>
               <p class="text-pnsqc-cyan mt-1">Tariq King</p>
@@ -60,7 +60,7 @@ og_image: /images/hero/hero-collaboration.png
 
         <article class="rounded-2xl border border-pnsqc-gold/20 bg-pnsqc-blue/10 p-6">
           <div class="flex items-start gap-4">
-            <img src="/images/brand/pnsqc-logo.jpg" alt="Workshop speaker avatar" class="w-14 h-14 rounded-lg object-cover ring-2 ring-pnsqc-gold/30">
+            <img src="/images/brand/pnsqc-logo.jpg" alt="Workshop speaker avatar" class="w-12 h-12 shrink-0 rounded-lg object-cover ring-2 ring-pnsqc-gold/30">
             <div>
               <h2 class="text-xl font-semibold text-white">Social Software Testing Approaches</h2>
               <p class="text-pnsqc-cyan mt-1">Maaret Pyhäjärvi</p>
@@ -72,7 +72,7 @@ og_image: /images/hero/hero-collaboration.png
 
         <article class="rounded-2xl border border-pnsqc-gold/20 bg-pnsqc-blue/10 p-6">
           <div class="flex items-start gap-4">
-            <img src="/images/brand/pnsqc-logo.jpg" alt="Workshop speaker avatar" class="w-14 h-14 rounded-lg object-cover ring-2 ring-pnsqc-gold/30">
+            <img src="/images/brand/pnsqc-logo.jpg" alt="Workshop speaker avatar" class="w-12 h-12 shrink-0 rounded-lg object-cover ring-2 ring-pnsqc-gold/30">
             <div>
               <h2 class="text-xl font-semibold text-white">Testing the Next Generation of AI-Based Software</h2>
               <p class="text-pnsqc-cyan mt-1">Jason Arbon</p>
@@ -84,7 +84,7 @@ og_image: /images/hero/hero-collaboration.png
 
         <article class="rounded-2xl border border-pnsqc-gold/20 bg-pnsqc-blue/10 p-6">
           <div class="flex items-start gap-4">
-            <img src="/images/brand/pnsqc-logo.jpg" alt="Workshop speaker avatar" class="w-14 h-14 rounded-lg object-cover ring-2 ring-pnsqc-gold/30">
+            <img src="/images/brand/pnsqc-logo.jpg" alt="Workshop speaker avatar" class="w-12 h-12 shrink-0 rounded-lg object-cover ring-2 ring-pnsqc-gold/30">
             <div>
               <h2 class="text-xl font-semibold text-white">Using Models to Define Test Plans</h2>
               <p class="text-pnsqc-cyan mt-1">Wayne Roseberry</p>
@@ -96,7 +96,7 @@ og_image: /images/hero/hero-collaboration.png
 
         <article class="rounded-2xl border border-pnsqc-gold/20 bg-pnsqc-blue/10 p-6">
           <div class="flex items-start gap-4">
-            <img src="/images/brand/pnsqc-logo.jpg" alt="Workshop speaker avatar" class="w-14 h-14 rounded-lg object-cover ring-2 ring-pnsqc-gold/30">
+            <img src="/images/brand/pnsqc-logo.jpg" alt="Workshop speaker avatar" class="w-12 h-12 shrink-0 rounded-lg object-cover ring-2 ring-pnsqc-gold/30">
             <div>
               <h2 class="text-xl font-semibold text-white">Integrate The Model Context Protocol (MCP) into your workflow</h2>
               <p class="text-pnsqc-cyan mt-1">Joe Petsche</p>
@@ -108,7 +108,7 @@ og_image: /images/hero/hero-collaboration.png
 
         <article class="rounded-2xl border border-pnsqc-gold/20 bg-pnsqc-blue/10 p-6">
           <div class="flex items-start gap-4">
-            <img src="/images/brand/pnsqc-logo.jpg" alt="Workshop speaker avatar" class="w-14 h-14 rounded-lg object-cover ring-2 ring-pnsqc-gold/30">
+            <img src="/images/brand/pnsqc-logo.jpg" alt="Workshop speaker avatar" class="w-12 h-12 shrink-0 rounded-lg object-cover ring-2 ring-pnsqc-gold/30">
             <div>
               <h2 class="text-xl font-semibold text-white">Testing Beyond Your Laptop with GitHub Actions</h2>
               <p class="text-pnsqc-cyan mt-1">Juan de Dios Delgado Bernal</p>
@@ -120,7 +120,7 @@ og_image: /images/hero/hero-collaboration.png
 
         <article class="rounded-2xl border border-pnsqc-gold/20 bg-pnsqc-blue/10 p-6">
           <div class="flex items-start gap-4">
-            <img src="/images/brand/pnsqc-logo.jpg" alt="Workshop speaker avatar" class="w-14 h-14 rounded-lg object-cover ring-2 ring-pnsqc-gold/30">
+            <img src="/images/brand/pnsqc-logo.jpg" alt="Workshop speaker avatar" class="w-12 h-12 shrink-0 rounded-lg object-cover ring-2 ring-pnsqc-gold/30">
             <div>
               <h2 class="text-xl font-semibold text-white">Quality Leadership in 2026: A Managers' Forum on Today's Hardest Problems</h2>
               <p class="text-pnsqc-cyan mt-1">Philip Lew</p>


### PR DESCRIPTION
Firefox was not properly respecting the image size for the profile icons next to each workshop card.