### PR TITLE
Added clarifying text for the CFP

### DIFF
--- a/src/cfp/index.html
+++ b/src/cfp/index.html
@@ -132,16 +132,20 @@ og_image: /images/events/conference/2025/group_photo.jpg
         <div class="space-y-4 text-pnsqc-slate text-lg leading-relaxed">
           <p>Many PNSQC authors submit their <strong>first conference paper</strong> here.</p>
           <p>
-            Accepted authors are paired with reviewers who provide feedback and guidance throughout
-            the writing process. The goal is not only to produce a strong paper, but also to help
+            You don’t need a perfect story. You need a real one. PNSQC reviewers provide you with feedback and help shape accepted talks. 
+            The goal is not only to produce a strong paper, but also to help
             authors develop their ideas and communication skills.
           </p>
           <p>
             Over the years, a number of well-known voices in the software quality community first
             presented their work at PNSQC before going on to speak at conferences around the world.
             For many authors, presenting at PNSQC becomes the
-            <strong>starting point for a broader speaking and publishing journey</strong>.
+            <strong>starting point for a broader speaking and publishing journey</strong>.  Many presentations started from basic ideas:
           </p>
+<li><i>"How we decide what NOT to test in a large system"</i></li>
+<li><i>"A quality failure that changed how our team works"</i></li>
+<li><i>"How product, UX, and QA disagreed—and what we learned"</i></li>
+
           <p>
             Each year PNSQC recognizes outstanding contributions with
             <strong>three Best Paper Awards</strong>. Award winners are typically invited to return

--- a/src/cfp/index.html
+++ b/src/cfp/index.html
@@ -44,22 +44,22 @@ og_image: /images/events/conference/2025/group_photo.jpg
           />
         </div>
 
-          <div class="mt-8 text-center">
-            <a
-              href="https://meetinghand.com/e/pnsqc-2026/abstract"
-              class="button-gold inline-flex items-center gap-2 px-10 py-5 font-bold text-lg rounded-lg transition-colors shadow-xl"
-            >
-              Submit your idea now!
-              <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                  stroke-width="2"
-                  d="M17 8l4 4m0 0l-4 4m4-4H3"
-                />
-              </svg>
-            </a>
-          </div>
+        <div class="mt-8 mb-8 text-center">
+          <a
+            href="https://meetinghand.com/e/pnsqc-2026/abstract"
+            class="button-gold inline-flex items-center gap-2 px-10 py-5 font-bold text-lg rounded-lg transition-colors shadow-xl"
+          >
+            Submit your idea now!
+            <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+                d="M17 8l4 4m0 0l-4 4m4-4H3"
+              />
+            </svg>
+          </a>
+        </div>
         <h2 class="text-xl sm:text-2xl font-bold text-white mb-6">
           Share Your Experience with the Software Quality Community
         </h2>
@@ -73,17 +73,21 @@ og_image: /images/events/conference/2025/group_photo.jpg
             <strong>peer-reviewed and published in our annual proceedings</strong>, contributing to
             the body of knowledge for the software quality profession.
           </p>
-          <p>
-           We are looking for abstracts:
+          <p>We are looking for abstracts:</p>
           <ul class="list-disc pl-6 space-y-2">
-          <li>Start with an idea you want to share about improving software quality.</li>
-          <li>Submit it as an abstract to PNSQC: a title and a 3-4 sentence summary of your idea.</li>
-          <li>Should your idea be accepted, the abstract you submit here will be the basis for a more detailed white paper you present
-          at PNSQC 2026.</li>
-          <li>From June to September PNSQC will provide peer reviewers to help you develop an 8-10 page paper that refines and
-          formalizes your idea.</li>
+            <li>Start with an idea you want to share about improving software quality.</li>
+            <li>
+              Submit it as an abstract to PNSQC: a title and a 3-4 sentence summary of your idea.
+            </li>
+            <li>
+              Should your idea be accepted, the abstract you submit here will be the basis for a
+              more detailed white paper you present at PNSQC 2026.
+            </li>
+            <li>
+              From June to September, PNSQC will provide peer reviewers to help you develop an 8-10
+              page paper that refines and formalizes your idea.
+            </li>
           </ul>
-          </p>
           <p>We welcome submissions from:</p>
           <ul class="list-disc pl-6 space-y-2">
             <li>practitioners working in industry</li>
@@ -159,21 +163,22 @@ og_image: /images/events/conference/2025/group_photo.jpg
         <div class="space-y-4 text-pnsqc-slate text-lg leading-relaxed">
           <p>Many PNSQC authors submit their <strong>first conference paper</strong> here.</p>
           <p>
-            You don’t need a perfect story. You need a real one. PNSQC reviewers provide you with feedback and help shape accepted talks. 
-            The goal is not only to produce a strong paper, but also to help
-            authors develop their ideas and communication skills.
+            You don’t need a perfect story. You need a real one. PNSQC reviewers provide you with
+            feedback and help shape accepted talks. The goal is not only to produce a strong paper,
+            but also to help authors develop their ideas and communication skills.
           </p>
           <p>
             Over the years, a number of well-known voices in the software quality community first
             presented their work at PNSQC before going on to speak at conferences around the world.
             For many authors, presenting at PNSQC becomes the
-            <strong>starting point for a broader speaking and publishing journey</strong>.  Many presentations started from basic ideas:
+            <strong>starting point for a broader speaking and publishing journey</strong>. Many
+            presentations started from basic ideas:
           </p>
           <ul class="list-disc pl-6 space-y-2">
-<li><i>"How we decide what NOT to test in a large system"</i></li>
-<li><i>"A quality failure that changed how our team works"</i></li>
-<li><i>"How product, UX, and QA disagreed—and what we learned"</i></li>
-</ul>
+            <li><i>"How we decide what NOT to test in a large system"</i></li>
+            <li><i>"A quality failure that changed how our team works"</i></li>
+            <li><i>"How product, UX, and QA disagreed—and what we learned"</i></li>
+          </ul>
           <p>
             Each year PNSQC recognizes outstanding contributions with
             <strong>three Best Paper Awards</strong>. Award winners are typically invited to return

--- a/src/cfp/index.html
+++ b/src/cfp/index.html
@@ -44,6 +44,22 @@ og_image: /images/events/conference/2025/group_photo.jpg
           />
         </div>
 
+          <div class="mt-8 text-center">
+            <a
+              href="https://meetinghand.com/e/pnsqc-2026/abstract"
+              class="button-gold inline-flex items-center gap-2 px-10 py-5 font-bold text-lg rounded-lg transition-colors shadow-xl"
+            >
+              Submit your idea now!
+              <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  stroke-width="2"
+                  d="M17 8l4 4m0 0l-4 4m4-4H3"
+                />
+              </svg>
+            </a>
+          </div>
         <h2 class="text-xl sm:text-2xl font-bold text-white mb-6">
           Share Your Experience with the Software Quality Community
         </h2>
@@ -56,6 +72,17 @@ og_image: /images/events/conference/2025/group_photo.jpg
             Unlike many conferences, PNSQC papers are
             <strong>peer-reviewed and published in our annual proceedings</strong>, contributing to
             the body of knowledge for the software quality profession.
+          </p>
+          <p>
+           We are looking for abstracts:
+          <ul class="list-disc pl-6 space-y-2">
+          <li>Start with an idea you want to share about improving software quality.</li>
+          <li>Submit it as an abstract to PNSQC: a title and a 3-4 sentence summary of your idea.</li>
+          <li>Should your idea be accepted, the abstract you submit here will be the basis for a more detailed white paper you present
+          at PNSQC 2026.</li>
+          <li>From June to September PNSQC will provide peer reviewers to help you develop an 8-10 page paper that refines and
+          formalizes your idea.</li>
+          </ul>
           </p>
           <p>We welcome submissions from:</p>
           <ul class="list-disc pl-6 space-y-2">
@@ -142,10 +169,11 @@ og_image: /images/events/conference/2025/group_photo.jpg
             For many authors, presenting at PNSQC becomes the
             <strong>starting point for a broader speaking and publishing journey</strong>.  Many presentations started from basic ideas:
           </p>
+          <ul class="list-disc pl-6 space-y-2">
 <li><i>"How we decide what NOT to test in a large system"</i></li>
 <li><i>"A quality failure that changed how our team works"</i></li>
 <li><i>"How product, UX, and QA disagreed—and what we learned"</i></li>
-
+</ul>
           <p>
             Each year PNSQC recognizes outstanding contributions with
             <strong>three Best Paper Awards</strong>. Award winners are typically invited to return

--- a/src/conference/2026/tracks/index.html
+++ b/src/conference/2026/tracks/index.html
@@ -104,7 +104,7 @@ og_image: /images/events/conference/2025/group_photo.jpg
 
             <p class="text-sm text-pnsqc-slate mb-5 leading-relaxed">
               Engineering practices, architectures, metrics, and reliability techniques grounded in
-              evidence and real-world experience.
+              evidence and real-world experience. For engineers and practitioners working on real systems who want to share how quality actually holds up under change.
             </p>
 
             <div class="space-y-2 mb-6">
@@ -191,7 +191,7 @@ og_image: /images/events/conference/2025/group_photo.jpg
 
             <p class="text-sm text-pnsqc-slate mb-5 leading-relaxed">
               Quality governance, decision frameworks, culture, and organizational strategy tied to
-              measurable outcomes.
+              measurable outcomes. For managers, leads, and teams figuring out how to make better decisions about quality, risk, and priorities.
             </p>
 
             <div class="space-y-2 mb-6">
@@ -277,7 +277,7 @@ og_image: /images/events/conference/2025/group_photo.jpg
 
             <p class="text-sm text-pnsqc-slate mb-5 leading-relaxed">
               Testing, evaluating, governing, and assuring trustworthy AI-enabled and intelligent
-              technologies.
+              technologies. For teams building or testing AI-enabled systems, or adapting quality practices in an AI-driven world.
             </p>
 
             <div class="space-y-2 mb-6">
@@ -355,7 +355,7 @@ og_image: /images/events/conference/2025/group_photo.jpg
             <h2 class="text-2xl font-bold text-white mb-3">Tools & Productivity</h2>
             <p class="text-sm text-pnsqc-slate mb-5 leading-relaxed">
               Practical tools, frameworks, and techniques that improve the productivity and
-              effectiveness of quality engineering teams.
+              effectiveness of quality engineering teams. For practitioners and tool builders demonstrating how work actually gets done.
             </p>
 
             <div class="space-y-2 mb-6">
@@ -444,6 +444,9 @@ og_image: /images/events/conference/2025/group_photo.jpg
     <template id="details-modal-template-track-1">
       <div class="rich-content rich-content--compact space-y-6">
         <p>
+          For engineers and practitioners working on real systems who want to share how quality actually holds up under change.
+        </p>
+        <p>
           This track focuses on how teams design, test, and sustain quality in software systems of
           all kinds, whether systems are built in-house, assembled from multiple components, or
           integrated with vendor-provided platforms.
@@ -488,6 +491,9 @@ og_image: /images/events/conference/2025/group_photo.jpg
     </template>
     <template id="details-modal-template-track-2">
       <div class="rich-content rich-content--compact space-y-6">
+        <p>
+          For managers, leads, and teams figuring out how to make better decisions about quality, risk, and priorities.
+        </p>
         <p>
           This track focuses on how people and organizations plan, govern, and sustain quality,
           especially as delivery speeds increase, systems grow more complex, and responsibility is
@@ -541,6 +547,9 @@ og_image: /images/events/conference/2025/group_photo.jpg
     <template id="details-modal-template-track-3">
       <div class="rich-content rich-content--compact space-y-6">
         <p>
+          For teams building or testing AI-enabled systems, or adapting quality practices in an AI-driven world.
+        </p>
+        <p>
           This track addresses quality challenges unique to AI-enabled and intelligent systems,
           including how such systems are evaluated, governed, and monitored in real-world use.
         </p>
@@ -585,8 +594,12 @@ og_image: /images/events/conference/2025/group_photo.jpg
     <template id="details-modal-template-track-4">
       <div class="rich-content rich-content--compact space-y-6">
         <p>
+          For practitioners and tool builders demonstrating how work actually gets done, with concrete 
+          workflows and lessons learned. Papers will show conditions before vs after, and will mention what doesn't work.
+        </p>
+        <p>
           This track focuses on practical tools, frameworks, and techniques that improve the
-          productivity and effectiveness of quality engineering teams.<br />
+          productivity and effectiveness of quality engineering teams. 
           Submissions should emphasize real-world experience, engineering insights, and lessons
           learned from building, integrating, or applying tools in modern software development
           environments.

--- a/src/conference/2026/tracks/index.html
+++ b/src/conference/2026/tracks/index.html
@@ -104,7 +104,8 @@ og_image: /images/events/conference/2025/group_photo.jpg
 
             <p class="text-sm text-pnsqc-slate mb-5 leading-relaxed">
               Engineering practices, architectures, metrics, and reliability techniques grounded in
-              evidence and real-world experience. For engineers and practitioners working on real systems who want to share how quality actually holds up under change.
+              evidence and real-world experience. For engineers and practitioners working on real
+              systems who want to share how quality actually holds up under change.
             </p>
 
             <div class="space-y-2 mb-6">
@@ -191,7 +192,8 @@ og_image: /images/events/conference/2025/group_photo.jpg
 
             <p class="text-sm text-pnsqc-slate mb-5 leading-relaxed">
               Quality governance, decision frameworks, culture, and organizational strategy tied to
-              measurable outcomes. For managers, leads, and teams figuring out how to make better decisions about quality, risk, and priorities.
+              measurable outcomes. For managers, leads, and teams figuring out how to make better
+              decisions about quality, risk, and priorities.
             </p>
 
             <div class="space-y-2 mb-6">
@@ -277,7 +279,8 @@ og_image: /images/events/conference/2025/group_photo.jpg
 
             <p class="text-sm text-pnsqc-slate mb-5 leading-relaxed">
               Testing, evaluating, governing, and assuring trustworthy AI-enabled and intelligent
-              technologies. For teams building or testing AI-enabled systems, or adapting quality practices in an AI-driven world.
+              technologies. For teams building or testing AI-enabled systems, or adapting quality
+              practices in an AI-driven world.
             </p>
 
             <div class="space-y-2 mb-6">
@@ -355,7 +358,8 @@ og_image: /images/events/conference/2025/group_photo.jpg
             <h2 class="text-2xl font-bold text-white mb-3">Tools & Productivity</h2>
             <p class="text-sm text-pnsqc-slate mb-5 leading-relaxed">
               Practical tools, frameworks, and techniques that improve the productivity and
-              effectiveness of quality engineering teams. For practitioners and tool builders demonstrating how work actually gets done.
+              effectiveness of quality engineering teams. For practitioners and tool builders
+              demonstrating how work actually gets done.
             </p>
 
             <div class="space-y-2 mb-6">
@@ -444,7 +448,8 @@ og_image: /images/events/conference/2025/group_photo.jpg
     <template id="details-modal-template-track-1">
       <div class="rich-content rich-content--compact space-y-6">
         <p>
-          For engineers and practitioners working on real systems who want to share how quality actually holds up under change.
+          For engineers and practitioners working on real systems who want to share how quality
+          actually holds up under change.
         </p>
         <p>
           This track focuses on how teams design, test, and sustain quality in software systems of
@@ -492,7 +497,8 @@ og_image: /images/events/conference/2025/group_photo.jpg
     <template id="details-modal-template-track-2">
       <div class="rich-content rich-content--compact space-y-6">
         <p>
-          For managers, leads, and teams figuring out how to make better decisions about quality, risk, and priorities.
+          For managers, leads, and teams figuring out how to make better decisions about quality,
+          risk, and priorities.
         </p>
         <p>
           This track focuses on how people and organizations plan, govern, and sustain quality,
@@ -547,7 +553,8 @@ og_image: /images/events/conference/2025/group_photo.jpg
     <template id="details-modal-template-track-3">
       <div class="rich-content rich-content--compact space-y-6">
         <p>
-          For teams building or testing AI-enabled systems, or adapting quality practices in an AI-driven world.
+          For teams building or testing AI-enabled systems, or adapting quality practices in an
+          AI-driven world.
         </p>
         <p>
           This track addresses quality challenges unique to AI-enabled and intelligent systems,
@@ -594,15 +601,15 @@ og_image: /images/events/conference/2025/group_photo.jpg
     <template id="details-modal-template-track-4">
       <div class="rich-content rich-content--compact space-y-6">
         <p>
-          For practitioners and tool builders demonstrating how work actually gets done, with concrete 
-          workflows and lessons learned. Papers will show conditions before vs after, and will mention what doesn't work.
+          For practitioners and tool builders demonstrating how work actually gets done, with
+          concrete workflows and lessons learned. Papers will show conditions before vs after, and
+          will mention what doesn't work.
         </p>
         <p>
           This track focuses on practical tools, frameworks, and techniques that improve the
-          productivity and effectiveness of quality engineering teams. 
-          Submissions should emphasize real-world experience, engineering insights, and lessons
-          learned from building, integrating, or applying tools in modern software development
-          environments.
+          productivity and effectiveness of quality engineering teams. Submissions should emphasize
+          real-world experience, engineering insights, and lessons learned from building,
+          integrating, or applying tools in modern software development environments.
         </p>
         <p>
           Submissions should focus on technical insights and practical experience rather than


### PR DESCRIPTION
1) Reframe each track with a “who this is for”
2) Elaborate on the process to encourage first time authors
3) Added clarification: we're only looking for the abstracts - papers to come later.